### PR TITLE
Adding a new neighbor should return a sender only when encrypted communication is ready

### DIFF
--- a/src/channeler/messages.rs
+++ b/src/channeler/messages.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+// use bytes::Bytes;
 
 use crypto::identity::PublicKey;
 
@@ -11,13 +11,13 @@ pub enum ToChannel {
     TimeTick,
 
     /// Request the `Channel` to send a message.
-    SendMessage(Bytes),
+    SendMessage(Vec<u8>),
 }
 
 /// The channel event expected to be sent to `Networker`.
 pub enum ChannelEvent {
     /// A message received from remote.
-    Message(Bytes),
+    Message(Vec<u8>),
 }
 
 /// The internal message expected to be sent to `Networker`.

--- a/src/networker/messages.rs
+++ b/src/networker/messages.rs
@@ -146,18 +146,13 @@ pub enum NetworkerToAppManager {
 }
 
 pub enum NetworkerToChanneler {
-    /// Request send message to remote.
-    SendChannelMessage {
-        neighbor_public_key: PublicKey,
-        content: Bytes,
-    },
     /// Request to add a new neighbor.
     AddNeighbor {
         info: ChannelerNeighborInfo,
-    },
-    /// Request to remove a neighbor.
-    RemoveNeighbor {
-        neighbor_public_key: PublicKey
+        /// Possibly return a sender. This sender is then used to send
+        /// messages to the new neighbor.
+        /// Communication to the new neighbor is closed by dropping the sender.
+        response_sender: oneshot::Sender<Option<mpsc::Sender<Vec<u8>>>>,
     },
 }
 


### PR DESCRIPTION
@kamyuentse : This is a proposal for breaking changes in the Channeler interface against the Networker. It allows the Networker to know that the Channeler level handshake is complete, so that messages may be sent to the remote neighbor.

This intends to solve the following problem: 
In the previous design, if the Networker adds a neighbor, the Networker can not know when is the neighbor ready for sending messages. If messages are sent too early they will be dropped by the Channeler.

This should have no effects on the design of the handshake state machine.

When you have some time please check this commit and tell me what you think. You might be able to see something that I'm missing.