### PR TITLE
Upgrade toolchain to 2018-05-23, and use clippy as cargo's subcommand.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu CC=gcc-6 CXX=g++-6 KCOV=1
       os: linux
-      rust: nightly-2018-05-20
+      rust: nightly-2018-05-23
       before_script:
         - travis/trusty/before-script.sh
       addons:
@@ -23,15 +23,15 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
       script:
-        - cargo test --features=dev --no-run
+        - cargo clean && cargo clippy
       after_success:
         - travis/trusty/after-success.sh
 
     - env: TARGET=x86_64-apple-darwin KCOV=0
       os: osx
-      rust: nightly-2018-05-20
+      rust: nightly-2018-05-23
       osx_image: xcode9.2
       before_script:
         - brew install capnp
       script:
-        - cargo test --features=dev
+        - cargo clean && cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 authors = ["real <real@freedomlayer.org>"]
 build = "build.rs"
 
-[features]
-default = []
-dev = ["clippy"]
-
 [[bin]]
 name = "main"
 path = "src/bin/main.rs"
@@ -28,10 +24,6 @@ tokio-core = "0.1"
 
 capnp = "0.8"
 rusqlite = "0.13"
-
-[dependencies.clippy]
-version = "=0.0.203"
-optional = true
 
 [dependencies.byteorder]
 version = "1.1"

--- a/README.md
+++ b/README.md
@@ -10,19 +10,36 @@ A Credit Switching engine written in Rust.
 
 Theoretically CSwitch should work anywhere Rust works (Windows, Linux, MacOS).
 
-- [Install Rust](https://www.rust-lang.org/install.html). We currently use
-    nightly Rust. You should pin to exact nightly Rust version, this could be
-    done using the command: `rustup override set nightly-YYYY-MM-DD`. Note that
-    this command should be run at the root of the repository. The current
-    nightly version could be found in .travis.yml.
+### Requirement
 
-- Install libsqlite3-dev. On ubuntu, run `sudo apt install libsqlite3-dev`.
-- [Install capnproto](https://capnproto.org/install.html). On Ubuntu, run `sudo apt install capnproto`
+- [SQLite3][sqlite], for persistent storage.
+- [Cap'n Proto][capnp], as ser&de protocol.
 
-After all is done, run 
+[sqlite]: https://www.sqlite.org
+[capnp]: https://capnproto.org
 
-```bash
-cargo test
-```
+Also, we need the Rust development toolchain.
 
-to make sure that all tests pass.
+### Install dependencies and toolchain
+
+- Install Rust development toolchain, we recommend [rustup](https://rustup.rs).
+- Install SQLite3:
+    - For Ubuntu user, run `sudo apt install libsqlite3-dev`
+    - For MacOS user, the SQLite3 is part of the system
+- Install capnproto:
+    - For Ubuntu user, run `sudo apt install capnproto`
+    - For MacOS user, it can be installed via Homebrew: `brew install canpnp`
+
+### Note for the toolchain version
+
+Currently we pinned the version of `Rust` and `clippy`, the newest version we used
+can be found in `.travis.yml`.
+
+You can run `rustup override set nightly-YYYY-MM-DD` to pinned Rust toolchain version
+under the root of the project, and `cargo install clippy --rev <commit hash>` to do
+the same for `clippy`.
+
+## Code of conduct
+
+Before you open a PR, all test should passed, also check the output of `clippy`,
+promise error free and make the warning as little as possible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,11 @@
 #![crate_type = "lib"]
+
 #![feature(nll)]
 #![feature(try_from)]
-#![feature(refcell_replace_swap)]
 #![feature(iterator_step_by)]
-#![cfg_attr(feature = "dev", feature(plugin))]
-#![cfg_attr(feature = "dev", plugin(clippy))]
-#![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
-#![allow(needless_pass_by_value)]
+#![feature(refcell_replace_swap)]
+#![cfg_attr(not(feature = "cargo-clippy"), allow(unknown_lints))]
+#![cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 
 extern crate byteorder;
 extern crate bytes;

--- a/travis/trusty/before-script.sh
+++ b/travis/trusty/before-script.sh
@@ -2,6 +2,9 @@
 
 set -eux -o pipefail
 
+CLIPPY_VERSION="0.0.204"
+CLIPPY_COMMIT_HASH="e7a3e03c6e"
+
 if [[ -f ".cargo/config" ]]; then
     rm .cargo/config
 elif [[ ! -d ".cargo" ]]; then
@@ -10,6 +13,14 @@ fi
 
 echo "[target.$TARGET]" > .cargo/config
 echo "linker= \"$CC\"" >> .cargo/config
+
+if [[ -f "$HOME/.cargo/bin/cargo-clippy" ]]; then
+    if [[ "$(cargo clippy --version)" -ne "$CLIPPY_VERSION" ]]; then
+        cargo install --force clippy --rev $CLIPPY_COMMIT_HASH
+    fi
+else
+    cargo install clippy --rev $CLIPPY_COMMIT_HASH
+fi
 
 cat .cargo/config
 


### PR DESCRIPTION
Closes #53 