### PR TITLE
Real/fix/bump rust clippy 2018 06 01

### DIFF
--- a/src/proto/proto_impl/channeler.rs
+++ b/src/proto/proto_impl/channeler.rs
@@ -23,8 +23,8 @@ impl<'a> Proto<'a> for InitChannel {
     }
 
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
-        write_rand_value(&self.rand_nonce, &mut to.borrow().init_rand_nonce())?;
-        write_public_key(&self.public_key, &mut to.borrow().init_public_key())?;
+        write_rand_value(&self.rand_nonce, &mut to.reborrow().init_rand_nonce())?;
+        write_public_key(&self.public_key, &mut to.reborrow().init_public_key())?;
 
         Ok(())
     }
@@ -55,12 +55,12 @@ impl<'a> Proto<'a> for ExchangePassive {
     }
 
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
-        write_hash_result(&self.prev_hash, &mut to.borrow().init_prev_hash())?;
-        write_rand_value(&self.rand_nonce, &mut to.borrow().init_rand_nonce())?;
-        write_public_key(&self.public_key, &mut to.borrow().init_public_key())?;
-        write_dh_public_key(&self.dh_public_key, &mut to.borrow().init_dh_public_key())?;
-        write_salt(&self.key_salt, &mut to.borrow().init_key_salt())?;
-        write_signature(&self.signature, &mut to.borrow().init_signature())?;
+        write_hash_result(&self.prev_hash, &mut to.reborrow().init_prev_hash())?;
+        write_rand_value(&self.rand_nonce, &mut to.reborrow().init_rand_nonce())?;
+        write_public_key(&self.public_key, &mut to.reborrow().init_public_key())?;
+        write_dh_public_key(&self.dh_public_key, &mut to.reborrow().init_dh_public_key())?;
+        write_salt(&self.key_salt, &mut to.reborrow().init_key_salt())?;
+        write_signature(&self.signature, &mut to.reborrow().init_signature())?;
 
         Ok(())
     }
@@ -87,10 +87,10 @@ impl<'a> Proto<'a> for ExchangeActive {
     }
 
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
-        write_hash_result(&self.prev_hash, &mut to.borrow().init_prev_hash())?;
-        write_dh_public_key(&self.dh_public_key, &mut to.borrow().init_dh_public_key())?;
-        write_salt(&self.key_salt, &mut to.borrow().init_key_salt())?;
-        write_signature(&self.signature, &mut to.borrow().init_signature())?;
+        write_hash_result(&self.prev_hash, &mut to.reborrow().init_prev_hash())?;
+        write_dh_public_key(&self.dh_public_key, &mut to.reborrow().init_dh_public_key())?;
+        write_salt(&self.key_salt, &mut to.reborrow().init_key_salt())?;
+        write_signature(&self.signature, &mut to.reborrow().init_signature())?;
 
         Ok(())
     }
@@ -113,8 +113,8 @@ impl<'a> Proto<'a> for ChannelReady {
     }
 
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
-        write_hash_result(&self.prev_hash, &mut to.borrow().init_prev_hash())?;
-        write_signature(&self.signature, &mut to.borrow().init_signature())?;
+        write_hash_result(&self.prev_hash, &mut to.reborrow().init_prev_hash())?;
+        write_signature(&self.signature, &mut to.reborrow().init_signature())?;
 
         Ok(())
     }
@@ -139,9 +139,9 @@ impl<'a> Proto<'a> for UnknownChannel {
     }
 
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
-        write_channel_id(&self.channel_id, &mut to.borrow().init_channel_id())?;
-        write_rand_value(&self.rand_nonce, &mut to.borrow().init_rand_nonce())?;
-        write_signature(&self.signature, &mut to.borrow().init_signature())?;
+        write_channel_id(&self.channel_id, &mut to.reborrow().init_channel_id())?;
+        write_rand_value(&self.rand_nonce, &mut to.reborrow().init_rand_nonce())?;
+        write_signature(&self.signature, &mut to.reborrow().init_signature())?;
 
         Ok(())
     }
@@ -169,7 +169,7 @@ impl<'a> Proto<'a> for PlainContent {
         match *self {
             PlainContent::KeepAlive => to.set_keep_alive(()),
             PlainContent::User(ref content) => {
-                to.borrow().init_user(content.len() as u32).copy_from_slice(content)
+                to.reborrow().init_user(content.len() as u32).copy_from_slice(content)
             }
         }
 
@@ -194,10 +194,10 @@ impl<'a> Proto<'a> for Plain {
     }
 
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
-        to.borrow().init_rand_padding(self.rand_padding.len() as u32)
+        to.reborrow().init_rand_padding(self.rand_padding.len() as u32)
             .copy_from_slice(&self.rand_padding);
 
-        self.content.write(&mut to.borrow().init_content())?;
+        self.content.write(&mut to.reborrow().init_content())?;
 
         Ok(())
     }
@@ -259,22 +259,22 @@ impl<'a> Proto<'a> for ChannelerMessage {
     fn write(&self, to: &mut Self::Writer) -> Result<(), ProtoError> {
         match *self {
             ChannelerMessage::InitChannel(ref init_channel) => {
-                init_channel.write(&mut to.borrow().init_init_channel())?;
+                init_channel.write(&mut to.reborrow().init_init_channel())?;
             }
             ChannelerMessage::ExchangePassive(ref exchange_passive) => {
-                exchange_passive.write(&mut to.borrow().init_exchange_passive())?;
+                exchange_passive.write(&mut to.reborrow().init_exchange_passive())?;
             }
             ChannelerMessage::ExchangeActive(ref exchange_active) => {
-                exchange_active.write(&mut to.borrow().init_exchange_active())?;
+                exchange_active.write(&mut to.reborrow().init_exchange_active())?;
             }
             ChannelerMessage::ChannelReady(ref channel_ready) => {
-                channel_ready.write(&mut to.borrow().init_channel_ready())?;
+                channel_ready.write(&mut to.reborrow().init_channel_ready())?;
             }
             ChannelerMessage::UnknownChannel(ref unknown_channel) => {
-                unknown_channel.write(&mut to.borrow().init_unknown_channel())?;
+                unknown_channel.write(&mut to.reborrow().init_unknown_channel())?;
             }
             ChannelerMessage::Encrypted(ref content) => {
-                let dst = to.borrow().init_encrypted(content.len() as u32);
+                let dst = to.reborrow().init_encrypted(content.len() as u32);
                 dst.copy_from_slice(content.as_ref());
             }
         }

--- a/src/proto/proto_impl/common.rs
+++ b/src/proto/proto_impl/common.rs
@@ -2,7 +2,6 @@ use std::io;
 use std::convert::TryFrom;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use byteorder::BigEndian;
 use capnp::struct_list;
 
 use crypto::rand_values::RandValue;
@@ -25,8 +24,8 @@ const CUSTOM_UINT512_LEN: usize = 64;
 pub fn read_custom_u_int128(from: &custom_u_int128::Reader) -> Result<Bytes, ProtoError> {
     let mut buffer = BytesMut::with_capacity(CUSTOM_UINT128_LEN);
 
-    buffer.put_u64::<BigEndian>(from.get_x0());
-    buffer.put_u64::<BigEndian>(from.get_x1());
+    buffer.put_u64_be(from.get_x0());
+    buffer.put_u64_be(from.get_x1());
 
     Ok(buffer.freeze())
 }
@@ -43,8 +42,8 @@ pub fn write_custom_u_int128<T: AsRef<[u8]>>(
 ) -> Result<(), ProtoError> {
     let mut reader = io::Cursor::new(from.as_ref());
 
-    to.set_x0(reader.get_u64::<BigEndian>());
-    to.set_x1(reader.get_u64::<BigEndian>());
+    to.set_x0(reader.get_u64_be());
+    to.set_x1(reader.get_u64_be());
 
     Ok(())
 }
@@ -54,10 +53,10 @@ pub fn write_custom_u_int128<T: AsRef<[u8]>>(
 pub fn read_custom_u_int256(from: &custom_u_int256::Reader) -> Result<Bytes, ProtoError> {
     let mut buffer = BytesMut::with_capacity(CUSTOM_UINT256_LEN);
 
-    buffer.put_u64::<BigEndian>(from.get_x0());
-    buffer.put_u64::<BigEndian>(from.get_x1());
-    buffer.put_u64::<BigEndian>(from.get_x2());
-    buffer.put_u64::<BigEndian>(from.get_x3());
+    buffer.put_u64_be(from.get_x0());
+    buffer.put_u64_be(from.get_x1());
+    buffer.put_u64_be(from.get_x2());
+    buffer.put_u64_be(from.get_x3());
 
     Ok(buffer.freeze())
 }
@@ -74,10 +73,10 @@ pub fn write_custom_u_int256<T: AsRef<[u8]>>(
 ) -> Result<(), ProtoError> {
     let mut reader = io::Cursor::new(from.as_ref());
 
-    to.set_x0(reader.get_u64::<BigEndian>());
-    to.set_x1(reader.get_u64::<BigEndian>());
-    to.set_x2(reader.get_u64::<BigEndian>());
-    to.set_x3(reader.get_u64::<BigEndian>());
+    to.set_x0(reader.get_u64_be());
+    to.set_x1(reader.get_u64_be());
+    to.set_x2(reader.get_u64_be());
+    to.set_x3(reader.get_u64_be());
 
     Ok(())
 }
@@ -87,14 +86,14 @@ pub fn write_custom_u_int256<T: AsRef<[u8]>>(
 pub fn read_custom_u_int512(from: &custom_u_int512::Reader) -> Result<Bytes, ProtoError> {
     let mut buffer = BytesMut::with_capacity(CUSTOM_UINT512_LEN);
 
-    buffer.put_u64::<BigEndian>(from.get_x0());
-    buffer.put_u64::<BigEndian>(from.get_x1());
-    buffer.put_u64::<BigEndian>(from.get_x2());
-    buffer.put_u64::<BigEndian>(from.get_x3());
-    buffer.put_u64::<BigEndian>(from.get_x4());
-    buffer.put_u64::<BigEndian>(from.get_x5());
-    buffer.put_u64::<BigEndian>(from.get_x6());
-    buffer.put_u64::<BigEndian>(from.get_x7());
+    buffer.put_u64_be(from.get_x0());
+    buffer.put_u64_be(from.get_x1());
+    buffer.put_u64_be(from.get_x2());
+    buffer.put_u64_be(from.get_x3());
+    buffer.put_u64_be(from.get_x4());
+    buffer.put_u64_be(from.get_x5());
+    buffer.put_u64_be(from.get_x6());
+    buffer.put_u64_be(from.get_x7());
 
     Ok(buffer.freeze())
 }
@@ -111,14 +110,14 @@ pub fn write_custom_u_int512<T: AsRef<[u8]>>(
 ) -> Result<(), ProtoError> {
     let mut reader = io::Cursor::new(from.as_ref());
 
-    to.set_x0(reader.get_u64::<BigEndian>());
-    to.set_x1(reader.get_u64::<BigEndian>());
-    to.set_x2(reader.get_u64::<BigEndian>());
-    to.set_x3(reader.get_u64::<BigEndian>());
-    to.set_x4(reader.get_u64::<BigEndian>());
-    to.set_x5(reader.get_u64::<BigEndian>());
-    to.set_x6(reader.get_u64::<BigEndian>());
-    to.set_x7(reader.get_u64::<BigEndian>());
+    to.set_x0(reader.get_u64_be());
+    to.set_x1(reader.get_u64_be());
+    to.set_x2(reader.get_u64_be());
+    to.set_x3(reader.get_u64_be());
+    to.set_x4(reader.get_u64_be());
+    to.set_x5(reader.get_u64_be());
+    to.set_x6(reader.get_u64_be());
+    to.set_x7(reader.get_u64_be());
 
     Ok(())
 }
@@ -206,7 +205,7 @@ pub fn write_public_key_list<'a>(
     debug_assert_eq!(from.len(), to.len() as usize);
 
     for (idx, ref_public_key) in from.iter().enumerate() {
-        let mut public_key_writer = to.borrow().get(idx as u32);
+        let mut public_key_writer = to.reborrow().get(idx as u32);
         write_public_key(ref_public_key, &mut public_key_writer)?;
     }
 
@@ -299,7 +298,7 @@ mod tests {
         let mut num_u128 = message.init_root::<custom_u_int128::Builder>();
         write_custom_u_int128(&in_buf, &mut num_u128).unwrap();
 
-        let out_buf = read_custom_u_int128(&num_u128.borrow_as_reader()).unwrap();
+        let out_buf = read_custom_u_int128(&num_u128.reborrow_as_reader()).unwrap();
 
         assert_eq!(&in_buf, &out_buf);
     }
@@ -318,7 +317,7 @@ mod tests {
         let mut num_u256 = message.init_root::<custom_u_int256::Builder>();
         write_custom_u_int256(&in_buf, &mut num_u256).unwrap();
 
-        let out_buf = read_custom_u_int256(&num_u256.borrow_as_reader()).unwrap();
+        let out_buf = read_custom_u_int256(&num_u256.reborrow_as_reader()).unwrap();
 
         assert_eq!(&in_buf, &out_buf);
     }
@@ -339,7 +338,7 @@ mod tests {
         let mut num_u512 = message.init_root::<custom_u_int512::Builder>();
         write_custom_u_int512(&in_buf, &mut num_u512).unwrap();
 
-        let out_buf = read_custom_u_int512(&num_u512.borrow_as_reader()).unwrap();
+        let out_buf = read_custom_u_int512(&num_u512.reborrow_as_reader()).unwrap();
 
         assert_eq!(&in_buf, &out_buf);
     }


### PR DESCRIPTION
Bumped rust and clippy versions. 
Made required changes to remove compile errors and warnings.
```
$ rustc --version
rustc 1.28.0-nightly (aa094a43c 2018-06-01)
$ cargo clippy --version
0.0.206
```
