### PR TITLE
Pointing to real/async_mutex with a specific commit hash.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio-core = "0.1"
 capnp = "0.8"
 rusqlite = "0.13"
 
-async_mutex = { git = "https://github.com/juchiast/async_mutex", tag = "v0.1.0" }
+async_mutex = { git = "https://github.com/realcr/async_mutex", rev = "a1d973ed7" }
 
 [dependencies.byteorder]
 version = "1.1"


### PR DESCRIPTION
When there are new tags we can point to a tag instead of a commit hash.