### PR TITLE
Removing .cargo/registry before build.

### DIFF
--- a/travis/trusty/before-script.sh
+++ b/travis/trusty/before-script.sh
@@ -10,6 +10,9 @@ elif [[ ! -d ".cargo" ]]; then
     mkdir .cargo
 fi
 
+# Clean any cache from cargo registry:
+rm -rf $HOME/.cargo/registry
+
 echo "[target.$TARGET]" > .cargo/config
 echo "linker= \"$CC\"" >> .cargo/config
 


### PR DESCRIPTION
@kamyuentse : This is another attempt at fixing the build of https://github.com/realcr/cswitch/pull/49
I logged in manually into the travis test machine and ran `rm -rf ~/.cargo/registry`, and it seemed to fix the problem. I tried to add this command to `before-script.sh`, hopefully it will work.

Maybe this problem is related to caching on the travis machine? It is interesting that other pull requests pass, but PR https://github.com/realcr/cswitch/pull/49 doesn't.