### PR TITLE
Pinned ring's version to 0.13.0-alpha, to avoid problems with DummyRa…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 pretty_env_logger = "0.2"
 
 rand = "0.4"
-ring = "0.13.0-alpha"
+ring = "=0.13.0-alpha"
 untrusted = "0.6"
 
 bytes = "0.4"


### PR DESCRIPTION
…ndom.

This is a temporary fix to the problem with DummyRandom, as noted in issue https://github.com/realcr/cswitch/issues/64 . We can leave it pinned until we find a solution. This could buy us some time to work on actual development (: 