### PR TITLE
Removed redundant balanceForReset (Saved in MessengerState).

### DIFF
--- a/src/proto/schema/app_manager.capnp
+++ b/src/proto/schema/app_manager.capnp
@@ -322,7 +322,6 @@ struct ResetNeighborChannel {
         neighborPublicKey @0: CustomUInt256;
         channelIndex @1: UInt16;
         currentToken @2: CustomUInt256;
-        balanceForReset @3: Int64;
 }
 
 enum NeighborStatus {
@@ -413,7 +412,6 @@ struct SetFriendRemoteMaxDebt {
 struct ResetFriendChannel {
         friendPublicKey @0: CustomUInt256;
         currentToken @1: CustomUInt256;
-        balanceForReset @2: CustomUInt128;
 }
 
 struct FriendUpdated {


### PR DESCRIPTION
I removed balanceForReset from both Reset messages (for Funder and Networker), as both Funder and Networker should retain this value in their internal state, so it is redundant.