### PR TITLE
Simplified exchange messages

### DIFF
--- a/src/proto/schema/app_manager.capnp
+++ b/src/proto/schema/app_manager.capnp
@@ -23,6 +23,8 @@ struct ExchangeDh {
         dhPublicKey @0: CustomUInt256;
         randNonce @1: CustomUInt128;
         # This is the nonce previously sent by the remote side.
+        keySalt @2: CustomUInt256;
+        signature @3: CustomUInt512;
 }
 
 


### PR DESCRIPTION
@juchiast : I have just seen your questions about serialization and boudaries, so I added this PR.

- I simplified here the diffie hellman exchange messages (Changed 4 messages into 2 messages), as I have noticed the messages are pretty much the same for both sides of the exchange.

In the beginning of the connection the following should happen:
- Client connects (TCP).
- Client sends ExchangeRandNonce.
- If the server does not have the public key sent as registered app, it will close the TCP connection. Otherwise, the server will respond with an ExchangeRandNonce.
- Both sides send ExchangeDh.
- A shared secret is derived on both sides.

Since that point, only encrypted messages could be sent. You need a codec to discover boundaries of encrypted messages.