### PR TITLE
Allowing FriendsRoute to be a single cycle.

### DIFF
--- a/components/funder/src/handler/handle_control.rs
+++ b/components/funder/src/handler/handle_control.rs
@@ -277,7 +277,7 @@ impl<A:Clone + 'static, R: CryptoRandom + 'static> MutableFunderHandler<A,R> {
 
         // We want to have at least two public keys on the route (source and destination).
         // We also want that the public keys on the route are unique.
-        if (route.len() < 2) || !route.is_cycle_free() {
+        if !route.is_valid() {
             return Err(HandleControlError::InvalidRoute);
         }
         let friend_public_key = route.public_keys[1].clone();

--- a/components/funder/src/mutual_credit/incoming.rs
+++ b/components/funder/src/mutual_credit/incoming.rs
@@ -52,7 +52,7 @@ pub enum ProcessOperationError {
     /// Trying to set the invoiceId, while already expecting another invoice id.
     PkPairNotInRoute,
     /// The Route contains some public key twice.
-    DuplicateNodesInRoute,
+    InvalidRoute,
     RequestsAlreadyDisabled,
     RouteTooLong,
     InsufficientTrust,
@@ -174,9 +174,8 @@ fn process_request_send_funds(mutual_credit: &mut MutualCredit,
                                 request_send_funds: RequestSendFunds)
     -> Result<ProcessOperationOutput, ProcessOperationError> {
 
-    // Make sure that the route does not contains cycles/duplicates:
-    if !request_send_funds.route.is_cycle_free() {
-        return Err(ProcessOperationError::DuplicateNodesInRoute);
+    if !request_send_funds.route.is_valid() {
+        return Err(ProcessOperationError::InvalidRoute);
     }
 
     // Find ourselves on the route. If we are not there, abort.

--- a/components/funder/src/mutual_credit/outgoing.rs
+++ b/components/funder/src/mutual_credit/outgoing.rs
@@ -38,7 +38,7 @@ pub enum QueueOperationError {
     InvalidSendFundsReceiptSignature,
     MissingRemoteInvoiceId,
     InvoiceIdMismatch,
-    DuplicateNodesInRoute,
+    InvalidRoute,
     PkPairNotInRoute,
     InvalidFreezeLinks,
     RemoteIncomingRequestsDisabled,
@@ -171,9 +171,8 @@ impl OutgoingMc {
     fn queue_request_send_funds(&mut self, request_send_funds: RequestSendFunds) ->
         Result<Vec<McMutation>, QueueOperationError> {
 
-        // Make sure that the route does not contains cycles/duplicates:
-        if !request_send_funds.route.is_cycle_free() {
-            return Err(QueueOperationError::DuplicateNodesInRoute);
+        if !request_send_funds.route.is_valid() {
+            return Err(QueueOperationError::InvalidRoute);
         }
 
         // Find ourselves on the route. If we are not there, abort.

--- a/components/funder/src/types.rs
+++ b/components/funder/src/types.rs
@@ -215,17 +215,29 @@ impl FriendsRoute {
         self.public_keys.len()
     }
 
-    /// Check if every node shows up in the route at most once.
-    /// This makes sure no cycles are present
-    pub fn is_cycle_free(&self) -> bool {
-        // All seen public keys:
+    /// Check if the route is valid.
+    /// A valid route must have at least 2 nodes, and is in one of the following forms:
+    /// A -- B -- C -- D -- E -- F -- A   (Single cycle, first == last)
+    /// A -- B -- C -- D -- E -- F        (A route with no repetitions)
+    pub fn is_valid(&self) -> bool {
+        if self.public_keys.len() < 2 {
+            return false;
+        }
+
         let mut seen = HashSet::new();
-        for public_key in &self.public_keys {
+        for public_key in &self.public_keys[.. self.public_keys.len() - 1] {
             if !seen.insert(public_key.clone()) {
-                return false
+                return false;
             }
         }
-        true
+        let last_pk = &self.public_keys[self.public_keys.len() - 1];
+        if last_pk == &self.public_keys[0] {
+            // The last public key closes a cycle
+            true
+        } else {
+            // A route with no repetitions
+            seen.insert(last_pk.clone())
+        }
     }
 
     /// Find two consecutive public keys (pk1, pk2) inside a friends route.


### PR DESCRIPTION
A valid route must have at least 2 nodes, and is in one of the following forms:
1. Single cycle, first == last :
`A -- B -- C -- D -- E -- F -- A`
2. A route with no repetitions:
`A -- B -- C -- D -- E -- F`        
