### PR TITLE
Changing reports to be differential

### DIFF
--- a/components/funder/src/ephemeral.rs
+++ b/components/funder/src/ephemeral.rs
@@ -1,19 +1,33 @@
-use super::freeze_guard::FreezeGuard;
-use super::liveness::Liveness;
+use super::freeze_guard::{FreezeGuard, FreezeGuardMutation};
+use super::liveness::{Liveness, LivenessMutation};
 use super::state::FunderState;
 
 #[derive(Clone)]
-pub struct FunderEphemeral {
+pub struct Ephemeral {
     pub freeze_guard: FreezeGuard,
     pub liveness: Liveness,
 }
 
-impl FunderEphemeral {
-    pub fn new<A: Clone>(funder_state: &FunderState<A>) -> FunderEphemeral {
-        FunderEphemeral {
+pub enum EphemeralMutation {
+    LivenessMutation(LivenessMutation),
+    FreezeGuardMutation(FreezeGuardMutation),
+}
+
+impl Ephemeral {
+    pub fn new<A: Clone>(funder_state: &FunderState<A>) -> Ephemeral {
+        Ephemeral {
             freeze_guard: FreezeGuard::new(&funder_state.local_public_key)
                 .load_funder_state(funder_state),
             liveness: Liveness::new(),
+        }
+    }
+
+    pub fn mutate(&mut self, mutation: &EphemeralMutation) {
+        match mutation {
+            EphemeralMutation::LivenessMutation(liveness_mutation) => 
+                self.liveness.mutate(liveness_mutation),
+            EphemeralMutation::FreezeGuardMutation(freeze_guard_mutation) => 
+                self.freeze_guard.mutate(freeze_guard_mutation),
         }
     }
 }

--- a/components/funder/src/friend.rs
+++ b/components/funder/src/friend.rs
@@ -51,6 +51,17 @@ pub enum ChannelStatus {
     Consistent(TokenChannel),
 }
 
+impl ChannelStatus {
+    pub fn get_last_incoming_move_token(&self) -> Option<FriendMoveToken> {
+        match &self {
+            ChannelStatus::Inconsistent(channel_inconsistent) => 
+                channel_inconsistent.opt_last_incoming_move_token.clone(),
+            ChannelStatus::Consistent(token_channel) => 
+                token_channel.get_last_incoming_move_token().cloned(),
+        }
+    }
+}
+
 
 #[allow(unused)]
 #[derive(Clone, Serialize, Deserialize)]

--- a/components/funder/src/friend.rs
+++ b/components/funder/src/friend.rs
@@ -38,7 +38,7 @@ pub enum FriendMutation<A> {
     RemoteReset(FriendMoveToken),
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
 pub struct ChannelInconsistent {
     pub opt_last_incoming_move_token: Option<FriendMoveToken>,
     pub local_reset_terms: ResetTerms,

--- a/components/funder/src/handler/mod.rs
+++ b/components/funder/src/handler/mod.rs
@@ -75,7 +75,7 @@ impl<A:Clone + 'static,R> MutableFunderHandler<A,R> {
         // If anything is expected to change with the state, add a report to be sent through the
         // outgoing control channel:
         if !self.mutations.is_empty() {
-            let funder_report = create_report(&self.state);
+            let funder_report = create_report(&self.state, &self.ephemeral.liveness);
             outgoing_control.push(FunderOutgoingControl::Report(funder_report));
         }
 

--- a/components/funder/src/liveness.rs
+++ b/components/funder/src/liveness.rs
@@ -6,6 +6,12 @@ pub struct Liveness {
     pub friends: ImHashSet<PublicKey>,
 }
 
+#[derive(Debug)]
+pub enum LivenessMutation {
+    SetOnline(PublicKey),
+    SetOffline(PublicKey),
+}
+
 
 impl Liveness {
     pub fn new() -> Liveness {
@@ -14,12 +20,15 @@ impl Liveness {
         }
     }
 
-    pub fn set_online(&mut self, friend_public_key: &PublicKey) {
-        self.friends.insert(friend_public_key.clone());
-    }
-
-    pub fn set_offline(&mut self, friend_public_key: &PublicKey) {
-        let _ = self.friends.remove(friend_public_key);
+    pub fn mutate(&mut self, mutation: &LivenessMutation) {
+        match mutation {
+            LivenessMutation::SetOnline(public_key) => {
+                self.friends.insert(public_key.clone());
+            },
+            LivenessMutation::SetOffline(public_key) => {
+                let _ = self.friends.remove(public_key);
+            },
+        }
     }
 
     pub fn is_online(&self, friend_public_key: &PublicKey) -> bool {
@@ -44,37 +53,37 @@ mod tests {
         assert!(!liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_online(&pk_a);
+        liveness.mutate(&LivenessMutation::SetOnline(pk_a.clone()));
         assert!(liveness.is_online(&pk_a));
         assert!(!liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_online(&pk_a);
+        liveness.mutate(&LivenessMutation::SetOnline(pk_a.clone()));
         assert!(liveness.is_online(&pk_a));
         assert!(!liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_online(&pk_b);
+        liveness.mutate(&LivenessMutation::SetOnline(pk_b.clone()));
         assert!(liveness.is_online(&pk_a));
         assert!(liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_offline(&pk_c);
+        liveness.mutate(&LivenessMutation::SetOffline(pk_c.clone()));
         assert!(liveness.is_online(&pk_a));
         assert!(liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_offline(&pk_b);
+        liveness.mutate(&LivenessMutation::SetOffline(pk_b.clone()));
         assert!(liveness.is_online(&pk_a));
         assert!(!liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_offline(&pk_b);
+        liveness.mutate(&LivenessMutation::SetOffline(pk_b.clone()));
         assert!(liveness.is_online(&pk_a));
         assert!(!liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));
 
-        liveness.set_offline(&pk_a);
+        liveness.mutate(&LivenessMutation::SetOffline(pk_a.clone()));
         assert!(!liveness.is_online(&pk_a));
         assert!(!liveness.is_online(&pk_b));
         assert!(!liveness.is_online(&pk_c));

--- a/components/funder/src/mutual_credit/types.rs
+++ b/components/funder/src/mutual_credit/types.rs
@@ -20,7 +20,7 @@ pub const MAX_FUNDER_DEBT: u128 = (1 << 127) - 1;
 
 // TODO: Rename this to McIdents
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct TcIdents {
+pub struct McIdents {
     /// My public key
     pub local_public_key: PublicKey,
     /// Friend's public key
@@ -29,7 +29,7 @@ pub struct TcIdents {
 
 // TODO: Rename this to McBalance
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct TcBalance {
+pub struct McBalance {
     /// Amount of credits this side has against the remote side.
     /// The other side keeps the negation of this value.
     pub balance: i128,
@@ -43,9 +43,9 @@ pub struct TcBalance {
     pub remote_pending_debt: u128,
 }
 
-impl TcBalance {
-    fn new(balance: i128) -> TcBalance {
-        TcBalance {
+impl McBalance {
+    fn new(balance: i128) -> McBalance {
+        McBalance {
             balance,
             remote_max_debt: cmp::max(balance, 0) as u128,
             local_max_debt: cmp::min(-balance, 0) as u128,
@@ -58,16 +58,16 @@ impl TcBalance {
 // TODO: Rename pending_local_requests to a shorter name, like local.
 
 #[derive(Clone, Serialize, Deserialize)]
-pub struct TcPendingRequests {
+pub struct McPendingRequests {
     /// Pending requests that were opened locally and not yet completed
     pub pending_local_requests: ImHashMap<Uid, PendingFriendRequest>,
     /// Pending requests that were opened remotely and not yet completed
     pub pending_remote_requests: ImHashMap<Uid, PendingFriendRequest>,
 }
 
-impl TcPendingRequests {
-    fn new() -> TcPendingRequests {
-        TcPendingRequests {
+impl McPendingRequests {
+    fn new() -> McPendingRequests {
+        McPendingRequests {
             pending_local_requests: ImHashMap::new(),
             pending_remote_requests: ImHashMap::new(),
         }
@@ -75,16 +75,16 @@ impl TcPendingRequests {
 }
 
 #[derive(Eq, PartialEq, Clone, Serialize, Deserialize, Debug)]
-pub struct TcRequestsStatus {
+pub struct McRequestsStatus {
     // Local is open/closed for incoming requests:
     pub local: RequestsStatus,
     // Remote is open/closed for incoming requests:
     pub remote: RequestsStatus,
 }
 
-impl TcRequestsStatus {
-    fn new() -> TcRequestsStatus {
-        TcRequestsStatus {
+impl McRequestsStatus {
+    fn new() -> McRequestsStatus {
+        McRequestsStatus {
             local: RequestsStatus::Closed,
             remote: RequestsStatus::Closed,
         }
@@ -94,10 +94,10 @@ impl TcRequestsStatus {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct MutualCreditState {
-    pub idents: TcIdents,
-    pub balance: TcBalance,
-    pub pending_requests: TcPendingRequests,
-    pub requests_status: TcRequestsStatus,
+    pub idents: McIdents,
+    pub balance: McBalance,
+    pub pending_requests: McPendingRequests,
+    pub requests_status: McRequestsStatus,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -128,13 +128,13 @@ impl MutualCredit {
 
         MutualCredit {
             state: MutualCreditState {
-                idents: TcIdents {
+                idents: McIdents {
                     local_public_key: local_public_key.clone(),
                     remote_public_key: remote_public_key.clone(),
                 },
-                balance: TcBalance::new(balance),
-                pending_requests: TcPendingRequests::new(),
-                requests_status: TcRequestsStatus::new(),
+                balance: McBalance::new(balance),
+                pending_requests: McPendingRequests::new(),
+                requests_status: McRequestsStatus::new(),
             }
         }
     }

--- a/components/funder/src/mutual_credit/types.rs
+++ b/components/funder/src/mutual_credit/types.rs
@@ -18,6 +18,7 @@ use super::super::types::RequestsStatus;
 pub const MAX_FUNDER_DEBT: u128 = (1 << 127) - 1;
 
 
+// TODO: Rename this to McIdents
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TcIdents {
     /// My public key
@@ -26,6 +27,7 @@ pub struct TcIdents {
     pub remote_public_key: PublicKey,
 }
 
+// TODO: Rename this to McBalance
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct TcBalance {
     /// Amount of credits this side has against the remote side.

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -51,7 +51,8 @@ pub enum ChannelStatusReport {
 
 #[derive(Clone, Debug)]
 pub struct FriendReport<A> {
-    pub remote_address: A, 
+    pub public_key: PublicKey,
+    pub address: A, 
     pub name: String,
     // Last message signed by the remote side. 
     // Can be used as a proof for the last known balance.
@@ -151,7 +152,8 @@ fn create_friend_report<A: Clone>(friend_state: &FriendState<A>, friend_liveness
     let channel_status = create_channel_status_report::<A>(&friend_state.channel_status);
 
     FriendReport {
-        remote_address: friend_state.remote_address.clone(),
+        public_key: friend_state.remote_public_key.clone(),
+        address: friend_state.remote_address.clone(),
         name: friend_state.name.clone(),
         opt_last_incoming_move_token: friend_state.channel_status.get_last_incoming_move_token(),
         liveness: friend_liveness.clone(),

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -36,6 +36,7 @@ pub enum ChannelStatusReport {
 #[derive(Clone, Debug)]
 pub struct FriendReport<A> {
     pub remote_address: A, 
+    pub name: String,
     pub channel_status: ChannelStatusReport,
     pub wanted_remote_max_debt: u128,
     pub wanted_local_requests_status: RequestsStatus,
@@ -54,6 +55,28 @@ pub struct FunderReport<A: Clone> {
     pub num_ready_receipts: usize,
     pub local_public_key: PublicKey,
 
+}
+
+#[allow(unused)]
+#[derive(Debug)]
+pub enum FriendReportMutation<A> {
+    SetFriendInfo((A, String)),
+    SetChannelStatus(ChannelStatusReport),
+    SetWantedRemoteMaxDebt(u128),
+    SetWantedLocalRequestsStatus(RequestsStatus),
+    SetNumPendingResponses(u64),
+    SetNumPendingRequests(u64),
+    SetFriendStatus(FriendStatus),
+    SetNumPendingUserRequests(u64),
+}
+
+#[allow(unused)]
+#[derive(Debug)]
+pub enum FunderReportMutation<A> {
+    AddFriend((PublicKey, A, String, i128)),
+    RemoveFriend(PublicKey),
+    FriendReportMutation((PublicKey, FriendReportMutation<A>)),
+    SetNumReadyReceipts(u64),
 }
 
 fn create_tc_report(mutual_credit: &MutualCredit) -> McReport {
@@ -79,10 +102,9 @@ fn create_friend_report<A: Clone>(friend_state: &FriendState<A>) -> FriendReport
         },
     };
 
-
-
     FriendReport {
         remote_address: friend_state.remote_address.clone(),
+        name: friend_state.name.clone(),
         channel_status,
         wanted_remote_max_debt: friend_state.wanted_remote_max_debt,
         wanted_local_requests_status: friend_state.wanted_local_requests_status.clone(),

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -51,7 +51,6 @@ pub enum ChannelStatusReport {
 
 #[derive(Clone, Debug)]
 pub struct FriendReport<A> {
-    pub public_key: PublicKey,
     pub address: A, 
     pub name: String,
     // Last message signed by the remote side. 
@@ -152,7 +151,6 @@ fn create_friend_report<A: Clone>(friend_state: &FriendState<A>, friend_liveness
     let channel_status = create_channel_status_report::<A>(&friend_state.channel_status);
 
     FriendReport {
-        public_key: friend_state.remote_public_key.clone(),
         address: friend_state.remote_address.clone(),
         name: friend_state.name.clone(),
         opt_last_incoming_move_token: friend_state.channel_status.get_last_incoming_move_token(),

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -195,14 +195,14 @@ pub fn create_funder_mutation_report<A: Clone + 'static>(funder_mutation: &Funde
         FunderMutation::RemoveFriend(friend_public_key) => {
             Some(FunderReportMutation::RemoveFriend(friend_public_key.clone()))
         },
-        FunderMutation::AddReceipt((uid, receipt)) => {
+        FunderMutation::AddReceipt((_uid, _receipt)) => {
             if funder_state_after.ready_receipts.len() != funder_state.ready_receipts.len() {
                 Some(FunderReportMutation::SetNumReadyReceipts(usize_to_u64(funder_state.ready_receipts.len()).unwrap()))
             } else {
                 None
             }
         },
-        FunderMutation::RemoveReceipt(uid) => {
+        FunderMutation::RemoveReceipt(_uid) => {
             if funder_state_after.ready_receipts.len() != funder_state.ready_receipts.len() {
                 Some(FunderReportMutation::SetNumReadyReceipts(usize_to_u64(funder_state.ready_receipts.len()).unwrap()))
             } else {

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -6,7 +6,7 @@ use utils::int_convert::usize_to_u64;
 use crate::friend::{FriendState, ChannelStatus, ChannelInconsistent, FriendMutation};
 use crate::state::{FunderState, FunderMutation};
 use crate::types::{RequestsStatus, FriendStatus, AddFriend, FriendMoveToken};
-use crate::mutual_credit::types::{TcBalance, TcRequestsStatus, MutualCredit};
+use crate::mutual_credit::types::{McBalance, McRequestsStatus, MutualCredit};
 use crate::token_channel::TcDirection; 
 
 #[derive(Clone, Debug)]
@@ -18,8 +18,8 @@ pub enum DirectionReport {
 #[derive(Clone, Debug)]
 pub struct TcReport {
     pub direction: DirectionReport,
-    pub balance: TcBalance,
-    pub requests_status: TcRequestsStatus,
+    pub balance: McBalance,
+    pub requests_status: McRequestsStatus,
     // Last signed statement from remote side:
     pub opt_last_incoming_move_token: Option<FriendMoveToken>,
 }

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -1,6 +1,7 @@
 use im::hashmap::HashMap as ImHashMap;
 
 use crypto::identity::PublicKey;
+use utils::int_convert::usize_to_u64;
 
 use super::friend::{FriendState, ChannelStatus, ChannelInconsistent};
 use super::state::FunderState;
@@ -40,11 +41,11 @@ pub struct FriendReport<A> {
     pub channel_status: ChannelStatusReport,
     pub wanted_remote_max_debt: u128,
     pub wanted_local_requests_status: RequestsStatus,
-    pub num_pending_responses: usize,
-    pub num_pending_requests: usize,
+    pub num_pending_responses: u64,
+    pub num_pending_requests: u64,
     // Pending operations to be sent to the token channel.
     pub status: FriendStatus,
-    pub num_pending_user_requests: usize,
+    pub num_pending_user_requests: u64,
     // Request that the user has sent to this neighbor, 
     // but have not been processed yet. Bounded in size.
 }
@@ -108,10 +109,10 @@ fn create_friend_report<A: Clone>(friend_state: &FriendState<A>) -> FriendReport
         channel_status,
         wanted_remote_max_debt: friend_state.wanted_remote_max_debt,
         wanted_local_requests_status: friend_state.wanted_local_requests_status.clone(),
-        num_pending_responses: friend_state.pending_responses.len(),
-        num_pending_requests: friend_state.pending_requests.len(),
+        num_pending_responses: usize_to_u64(friend_state.pending_responses.len()).unwrap(),
+        num_pending_requests: usize_to_u64(friend_state.pending_requests.len()).unwrap(),
         status: friend_state.status.clone(),
-        num_pending_user_requests: friend_state.pending_user_requests.len(),
+        num_pending_user_requests: usize_to_u64(friend_state.pending_user_requests.len()).unwrap(),
     }
 }
 

--- a/components/funder/src/report.rs
+++ b/components/funder/src/report.rs
@@ -24,7 +24,6 @@ pub enum DirectionReport {
 #[derive(Clone, Debug)]
 pub struct TcReport {
     pub direction: DirectionReport,
-    // Equals Sha512/256(FriendMoveToken)
     pub mutual_credit: McReport,
 }
 

--- a/components/funder/src/state.rs
+++ b/components/funder/src/state.rs
@@ -113,7 +113,7 @@ impl<A:Clone + 'static> FunderState<A> {
                                                   add_friend.address.clone(),
                                                   add_friend.name.clone(),
                                                   add_friend.balance);
-                // Insert friend, but also make sure that we did not remove any existing friend
+                // Insert friend, but also make sure that we didn't override an existing friend
                 // with the same public key:
                 let res = self.friends.insert(add_friend.friend_public_key.clone(), friend);
                 assert!(res.is_none());

--- a/components/funder/src/types.rs
+++ b/components/funder/src/types.rs
@@ -13,7 +13,7 @@ use crypto::hash::{HashResult, sha_512_256};
 use identity::IdentityClient;
 
 use super::messages::ResponseSendFundsResult;
-use super::report::FunderReport;
+use super::report::{FunderReport, FunderReportMutation};
 
 // Prefix used for chain hashing of token channel funds.
 // NEXT is used for hashing for the next move token funds.
@@ -573,6 +573,7 @@ pub enum FunderOutgoing<A: Clone> {
 pub enum FunderOutgoingControl<A: Clone> {
     ResponseReceived(ResponseReceived),
     Report(FunderReport<A>),
+    ReportMutations(Vec<FunderReportMutation<A>>),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The Funder will send a full report (A summary of the state) through the control channel when it starts. Then it will only send differential reports. The recipient, AppServer, should build the differential reports upon the first full report.