### PR TITLE
Implement FutTransform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,6 @@ dependencies = [
  "offst-crypto 0.1.0",
  "offst-identity 0.1.0",
  "offst-proto 0.1.0",
- "offst-relay 0.1.0",
  "offst-timer 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,6 @@ dependencies = [
  "offst-identity 0.1.0",
  "offst-proto 0.1.0",
  "offst-relay 0.1.0",
- "offst-secure-channel 0.1.0",
  "offst-timer 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "offst-common 0.1.0",
  "offst-crypto 0.1.0",
- "offst-keepalive 0.1.0",
  "offst-proto 0.1.0",
  "offst-timer 0.1.0",
 ]

--- a/components/channeler/Cargo.toml
+++ b/components/channeler/Cargo.toml
@@ -13,7 +13,6 @@ identity = { path = "../identity", version = "0.1.0" , package = "offst-identity
 timer = { path = "../timer", version = "0.1.0" , package = "offst-timer" }
 proto = { path = "../proto", version = "0.1.0" , package = "offst-proto" }
 relay = { path = "../relay", version = "0.1.0" , package = "offst-relay" }
-secure_channel = { path = "../secure_channel", version = "0.1.0" , package = "offst-secure-channel" }
 
 log = "0.4"
 futures-preview = "0.3.0-alpha.10"

--- a/components/channeler/Cargo.toml
+++ b/components/channeler/Cargo.toml
@@ -12,7 +12,6 @@ crypto = { path = "../crypto", version = "0.1.0", package = "offst-crypto" }
 identity = { path = "../identity", version = "0.1.0" , package = "offst-identity" }
 timer = { path = "../timer", version = "0.1.0" , package = "offst-timer" }
 proto = { path = "../proto", version = "0.1.0" , package = "offst-proto" }
-relay = { path = "../relay", version = "0.1.0" , package = "offst-relay" }
 
 log = "0.4"
 futures-preview = "0.3.0-alpha.10"

--- a/components/channeler/src/channeler.rs
+++ b/components/channeler/src/channeler.rs
@@ -156,8 +156,7 @@ where
             };
             match select_res {
                 Some(conn_pair) => {
-                    await!(c_connections_sender.send((public_key.clone(), conn_pair)))
-                        .map_err(|_| unreachable!());
+                    await!(c_connections_sender.send((public_key.clone(), conn_pair))).unwrap();
                 },
                 None => {/* Canceled */},
             };
@@ -408,7 +407,7 @@ mod tests {
     use super::*;
     use futures::executor::ThreadPool;
 
-    use common::dummy_connector::{DummyConnector, ConnRequest};
+    use common::dummy_connector::DummyConnector;
     use common::dummy_listener::DummyListener;
     use crypto::identity::{PublicKey, PUBLIC_KEY_LEN};
 
@@ -562,7 +561,7 @@ mod tests {
         pks.sort_by(compare_public_key);
 
 
-        let (conn_request_sender, mut conn_request_receiver) = mpsc::channel(0);
+        let (conn_request_sender, _conn_request_receiver) = mpsc::channel(0);
         let connector = DummyConnector::new(conn_request_sender);
 
         let (listener_req_sender, mut listener_req_receiver) = mpsc::channel(0);

--- a/components/channeler/src/connect.rs
+++ b/components/channeler/src/connect.rs
@@ -32,6 +32,7 @@ pub struct ChannelerConnector<C,T,S> {
 }
 
 impl<C,T,S> ChannelerConnector<C,T,S> {
+    #[allow(unused)]
     pub fn new(client_connector: C,
                encrypt_transform: T,
                backoff_ticks: usize,
@@ -87,7 +88,7 @@ mod tests {
     use timer::{create_timer_incoming, dummy_timer_multi_sender, TimerTick};
     use crypto::identity::PUBLIC_KEY_LEN;
 
-    use common::dummy_connector::{DummyConnector, ConnRequest};
+    use common::dummy_connector::DummyConnector;
     use common::conn::FuncFutTransform;
 
 
@@ -107,7 +108,7 @@ mod tests {
         let client_connector = DummyConnector::new(conn_request_sender);
 
         // We don't need encryption for this test:
-        let encrypt_transform = FuncFutTransform::new(|(opt_public_key, conn_pair)| Some(conn_pair));
+        let encrypt_transform = FuncFutTransform::new(|(_opt_public_key, conn_pair)| Some(conn_pair));
 
         let mut channeler_connector = ChannelerConnector::new(
             client_connector,
@@ -157,7 +158,7 @@ mod tests {
         let client_connector = DummyConnector::new(conn_request_sender);
 
         // We don't need encryption for this test:
-        let encrypt_transform = FuncFutTransform::new(|(opt_public_key, conn_pair)| Some(conn_pair));
+        let encrypt_transform = FuncFutTransform::new(|(_opt_public_key, conn_pair)| Some(conn_pair));
 
         let mut channeler_connector = ChannelerConnector::new(
             client_connector,

--- a/components/channeler/src/listen.rs
+++ b/components/channeler/src/listen.rs
@@ -1,5 +1,5 @@
 use std::marker::Unpin;
-use futures::{select, future, FutureExt, TryFutureExt, stream, Stream, StreamExt, Sink, SinkExt};
+use futures::{select, FutureExt, TryFutureExt, StreamExt, Sink, SinkExt};
 use futures::task::{Spawn, SpawnExt};
 use futures::channel::mpsc;
 
@@ -84,6 +84,7 @@ where
     S: Spawn + Clone + Send + 'static,
 {
 
+    #[allow(unused)]
     pub fn new(client_listener: L,
            encrypt_transform: T,
            address: A,
@@ -141,7 +142,7 @@ where
                    mut access_control: AccessControlPk)
                     -> Result<!, ListenError> {
 
-        let (mut plain_connections_sender, plain_connections_receiver) = mpsc::channel(0);
+        let (plain_connections_sender, plain_connections_receiver) = mpsc::channel(0);
         self.spawner.spawn(conn_encryptor(plain_connections_receiver, 
                                           self.encrypt_transform.clone(),
                                           connections_sender.clone(), // Sends encrypted connections
@@ -150,7 +151,7 @@ where
 
         loop {
 
-            let (mut access_control_sender, mut connections_receiver) = 
+            let (access_control_sender, connections_receiver) = 
                 self.client_listener.clone().listen((relay_address.clone(), access_control.clone()));
 
             await!(self.listen_iter(plain_connections_sender.clone(),
@@ -237,7 +238,7 @@ mod tests {
         let public_key_c = PublicKey::from(&[0xcc; PUBLIC_KEY_LEN]);
 
         // We don't need encryption for this test:
-        let encrypt_transform = FuncFutTransform::new(|(opt_public_key, conn_pair)| Some(conn_pair));
+        let encrypt_transform = FuncFutTransform::new(|(_opt_public_key, conn_pair)| Some(conn_pair));
         let relay_address = 0x1337u32;
 
         let channeler_listener = ChannelerListener::new(
@@ -325,7 +326,7 @@ mod tests {
         let public_key_c = PublicKey::from(&[0xcc; PUBLIC_KEY_LEN]);
 
         // We don't need encryption for this test:
-        let encrypt_transform = FuncFutTransform::new(|(opt_public_key, conn_pair)| Some(conn_pair));
+        let encrypt_transform = FuncFutTransform::new(|(_opt_public_key, conn_pair)| Some(conn_pair));
         let relay_address = 0x1337u32;
 
         let channeler_listener = ChannelerListener::new(

--- a/components/common/src/access_control.rs
+++ b/components/common/src/access_control.rs
@@ -1,38 +1,40 @@
-use crypto::identity::PublicKey;
 use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum AccessControlOp {
-    Add(PublicKey),
-    Remove(PublicKey),
+pub enum AccessControlOp<T> {
+    Add(T),
+    Remove(T),
 }
 
 #[derive(Clone, Debug)]
-pub struct AccessControl {
-    allowed: HashSet<PublicKey>,
+pub struct AccessControl<T: std::cmp::Eq + std::hash::Hash> {
+    allowed: HashSet<T>,
 }
 
-impl AccessControl {
-    pub fn new() -> AccessControl {
+impl<T> AccessControl<T> 
+where
+    T: std::cmp::Eq + std::hash::Hash,
+{
+    pub fn new() -> AccessControl<T> {
         AccessControl {
             allowed: HashSet::new(),
         }
     }
 
-    pub fn apply_op(&mut self, allowed_op: AccessControlOp) {
+    pub fn apply_op(&mut self, allowed_op: AccessControlOp<T>) {
         match allowed_op {
-            AccessControlOp::Add(public_key) => {
-                self.allowed.insert(public_key);
+            AccessControlOp::Add(item) => {
+                self.allowed.insert(item);
             }
-            AccessControlOp::Remove(public_key) => {
-                self.allowed.remove(&public_key);
+            AccessControlOp::Remove(item) => {
+                self.allowed.remove(&item);
             }
         }
     }
 
     /// Check if a certain public key is allowed.
-    pub fn is_allowed(&self, public_key: &PublicKey) -> bool {
-        self.allowed.contains(public_key)
+    pub fn is_allowed(&self, item: &T) -> bool {
+        self.allowed.contains(item)
     }
 }
 
@@ -40,12 +42,11 @@ impl AccessControl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crypto::identity::{PublicKey, PUBLIC_KEY_LEN};
 
     #[test]
     fn test_access_control_basic() {
-        let a_public_key = PublicKey::from(&[0xaa; PUBLIC_KEY_LEN]);
-        let b_public_key = PublicKey::from(&[0xbb; PUBLIC_KEY_LEN]);
+        let a_public_key = 0xaa;
+        let b_public_key = 0xbb;
 
         let mut ac = AccessControl::new();
         assert!(!ac.is_allowed(&a_public_key));

--- a/components/common/src/conn.rs
+++ b/components/common/src/conn.rs
@@ -27,19 +27,6 @@ pub trait Listener {
                              mpsc::Receiver<Self::Connection>);
 }
 
-/// Transform a connection into another connection
-pub trait ConnTransform {
-    type OldSendItem;
-    type OldRecvItem;
-    type NewSendItem;
-    type NewRecvItem;
-    type Arg;
-
-    fn transform(&mut self, arg: Self::Arg, conn_pair: ConnPair<Self::OldSendItem, Self::OldRecvItem>) 
-        -> BoxFuture<'_, Option<ConnPair<Self::NewSendItem, Self::NewRecvItem>>>;
-}
-
-
 /// Apply a futuristic function over an input. Returns a boxed future that resolves
 /// to type Output.
 ///
@@ -94,48 +81,6 @@ where
     }
 }
 
-
-
-
-
-/// The Identity connection transformation.
-/// Returns exactly the same connection it has received.
-#[derive(Clone)]
-pub struct IdentityConnTransform<SI,RI,ARG> {
-    phantom_send_item: PhantomData<SI>,
-    phantom_recv_item: PhantomData<RI>,
-    phantom_arg: PhantomData<ARG>,
-}
-
-impl<SI,RI,ARG> IdentityConnTransform<SI,RI,ARG> {
-    pub fn new() -> IdentityConnTransform<SI,RI,ARG> {
-        IdentityConnTransform {
-            phantom_send_item: PhantomData,
-            phantom_recv_item: PhantomData,
-            phantom_arg: PhantomData,
-        }
-    }
-
-}
-
-
-impl<SI,RI,ARG> ConnTransform for IdentityConnTransform<SI,RI,ARG> 
-where
-    SI: Send,
-    RI: Send,
-{
-    type OldSendItem = SI;
-    type OldRecvItem = RI;
-    type NewSendItem = SI;
-    type NewRecvItem = RI;
-    type Arg = ARG;
-
-    fn transform(&mut self, _arg: ARG, conn_pair: ConnPair<SI,RI>) 
-        -> BoxFuture<'_, Option<ConnPair<SI,RI>>> {
-
-        Box::pinned(future::ready(Some(conn_pair)))
-    }
-}
 
 /// Wraps an FnMut type in a type that implements FutTransform.
 /// This could help mocking a FutTransform with a simple non futuristic function.

--- a/components/common/src/conn.rs
+++ b/components/common/src/conn.rs
@@ -40,6 +40,24 @@ pub trait ConnTransform {
 }
 
 
+/// Apply a futuristic function over an input. Returns a boxed future that resolves
+/// to type Output.
+///
+/// Idealy we would have used `FnMut(Input) -> BoxFuture<'_, Output>`,
+/// but implementing FnMut requires first that FnOnce will be implemented, and due to syntactic
+/// lifetime issues we didn't find a way to implement it. See also:
+///
+/// https://users.rust-lang.org/t/implementing-fnmut-with-lifetime/2620
+/// https://stackoverflow.com/questions/32219798/
+///             how-to-implement-fnmut-which-returns-reference-with-lifetime-parameter
+///
+pub trait FutTransform {
+    type Input;
+    type Output;
+
+    fn transform(&mut self, input: Self::Input)
+        -> BoxFuture<'_, Self::Output>;
+}
 
 
 

--- a/components/common/src/dummy_connector.rs
+++ b/components/common/src/dummy_connector.rs
@@ -1,41 +1,50 @@
 use futures::channel::{mpsc, oneshot};
 use futures::SinkExt;
-use crate::conn::{FutTransform, ConnPair, BoxFuture};
+use crate::conn::{FutTransform, BoxFuture};
 
 
-pub struct ConnRequest<SI,RI,A> {
+pub struct ConnRequest<A,O> {
     pub address: A,
-    response_sender: oneshot::Sender<Option<ConnPair<SI,RI>>>,
+    response_sender: oneshot::Sender<O>,
 }
 
-impl<SI,RI,A> ConnRequest<SI,RI,A> {
-    pub fn reply(self, opt_conn_pair: Option<ConnPair<SI,RI>>) {
-        self.response_sender.send(opt_conn_pair).ok().unwrap();
+impl<A,O> ConnRequest<A,O> {
+    pub fn reply(self, response: O) {
+        self.response_sender.send(response).ok().unwrap();
     }
 }
 
 /// A connector that contains only one pre-created connection.
-#[derive(Clone)]
-pub struct DummyConnector<SI,RI,A> {
-    req_sender: mpsc::Sender<ConnRequest<SI,RI,A>>,
+pub struct DummyConnector<A,O> {
+    req_sender: mpsc::Sender<ConnRequest<A,O>>,
 }
 
-impl<SI,RI,A> DummyConnector<SI,RI,A> {
-    pub fn new(req_sender: mpsc::Sender<ConnRequest<SI,RI,A>>) -> Self {
+impl<A,O> DummyConnector<A,O> {
+    pub fn new(req_sender: mpsc::Sender<ConnRequest<A,O>>) -> Self {
         DummyConnector { 
             req_sender,
         }
     }
 }
 
-impl<SI,RI,A> FutTransform for DummyConnector<SI,RI,A> 
+// TODO: Why didn't the automatic #[derive(Clone)] works for DummyListener?
+// Seemed like it had a problem with having config_receiver inside ListenRequest.
+// This is a workaround for this issue:
+impl<A,O> Clone for DummyConnector<A,O> {
+    fn clone(&self) -> DummyConnector<A,O> {
+        DummyConnector {
+            req_sender: self.req_sender.clone(),
+        }
+    }
+}
+
+impl<A,O> FutTransform for DummyConnector<A,O> 
 where
-    SI: Send,
-    RI: Send,
+    O: Send,
     A: Send + Sync,
 {
     type Input = A;
-    type Output = Option<ConnPair<SI,RI>>;
+    type Output = O;
 
     fn transform<'a>(&'a mut self, address: A) -> BoxFuture<'_, Self::Output> {
         let (response_sender, response_receiver) = oneshot::channel();
@@ -46,7 +55,7 @@ where
 
         let fut_conn_pair = async move {
             await!(self.req_sender.send(conn_request)).unwrap();
-            await!(response_receiver).ok()?
+            await!(response_receiver).unwrap()
         };
         Box::pinned(fut_conn_pair)
     }

--- a/components/common/src/dummy_connector.rs
+++ b/components/common/src/dummy_connector.rs
@@ -1,6 +1,6 @@
 use futures::channel::{mpsc, oneshot};
 use futures::SinkExt;
-use crate::conn::{Connector, ConnPair, BoxFuture};
+use crate::conn::{FutTransform, ConnPair, BoxFuture};
 
 
 pub struct ConnRequest<SI,RI,A> {
@@ -28,17 +28,16 @@ impl<SI,RI,A> DummyConnector<SI,RI,A> {
     }
 }
 
-impl<SI,RI,A> Connector for DummyConnector<SI,RI,A> 
+impl<SI,RI,A> FutTransform for DummyConnector<SI,RI,A> 
 where
     SI: Send,
     RI: Send,
     A: Send + Sync,
 {
-    type Address = A;
-    type SendItem = SI;
-    type RecvItem = RI;
+    type Input = A;
+    type Output = Option<ConnPair<SI,RI>>;
 
-    fn connect<'a>(&'a mut self, address: A) -> BoxFuture<'_, Option<ConnPair<Self::SendItem, Self::RecvItem>>> {
+    fn transform<'a>(&'a mut self, address: A) -> BoxFuture<'_, Self::Output> {
         let (response_sender, response_receiver) = oneshot::channel();
         let conn_request = ConnRequest {
             address,

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -21,4 +21,5 @@ pub mod futures_compat;
 pub mod conn;
 pub mod dummy_connector;
 pub mod dummy_listener;
+pub mod access_control;
 

--- a/components/keepalive/src/keepalive.rs
+++ b/components/keepalive/src/keepalive.rs
@@ -132,6 +132,7 @@ where
     Ok(())
 }
 
+/*
 /// Wrap a channel of communication, taking care of keepalives.
 pub fn keepalive_channel<TR, FR, TS, S>(to_remote: TR, from_remote: FR, 
                   timer_stream: TS,
@@ -160,8 +161,10 @@ where
     (user_sender, user_receiver)
 }
 
+*/
+
 #[derive(Clone)]
-struct KeepAliveChannel<S> {
+pub struct KeepAliveChannel<S> {
     timer_client: TimerClient,
     keepalive_ticks: usize,
     spawner: S,

--- a/components/keepalive/src/lib.rs
+++ b/components/keepalive/src/lib.rs
@@ -11,6 +11,6 @@ extern crate log;
 
 mod keepalive;
 
-pub use self::keepalive::keepalive_channel;
+pub use self::keepalive::KeepAliveChannel;
 
 

--- a/components/keepalive/src/lib.rs
+++ b/components/keepalive/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(generators)]
 #![feature(never_type)]
 #![feature(dbg_macro)]
+#![feature(unboxed_closures)]
 
 #[macro_use]
 extern crate log;

--- a/components/relay/Cargo.toml
+++ b/components/relay/Cargo.toml
@@ -11,7 +11,6 @@ common = { path = "../common", version = "0.1.0", package = "offst-common" }
 crypto = { path = "../crypto", version = "0.1.0", package = "offst-crypto" }
 timer = { path = "../timer", version = "0.1.0" , package = "offst-timer" }
 proto = { path = "../proto", version = "0.1.0" , package = "offst-proto" }
-keepalive = { path = "../keepalive", version = "0.1.0" , package = "offst-keepalive" }
 
 log = "0.4"
 futures-preview = "0.3.0-alpha.10"

--- a/components/relay/src/client/client_connector.rs
+++ b/components/relay/src/client/client_connector.rs
@@ -1,15 +1,11 @@
 use crypto::identity::PublicKey;
-use futures::{future, FutureExt, TryFutureExt, StreamExt, SinkExt};
-use futures::task::{Spawn, SpawnExt};
-use futures::channel::mpsc;
+use futures::{FutureExt, SinkExt};
 
 use common::conn::{BoxFuture, Connector, 
     ConnPair, ConnTransform};
 
 use proto::relay::messages::{InitConnection};
 use proto::relay::serialize::serialize_init_connection;
-
-use timer::TimerClient;
 
 
 #[derive(Debug)]
@@ -96,19 +92,17 @@ where
 mod tests {
     use super::*;
     use futures::executor::ThreadPool;
+    use futures::channel::mpsc;
+    use futures::task::{Spawn, SpawnExt};
+    use futures::StreamExt;
 
-    use timer::{create_timer_incoming};
     use crypto::identity::{PUBLIC_KEY_LEN};
     use proto::relay::serialize::deserialize_init_connection;
 
     use common::dummy_connector::DummyConnector;
     use common::conn::IdentityConnTransform;
 
-
     async fn task_client_connector_basic(mut spawner: impl Spawn + Clone + Sync + Send + 'static) {
-        // Create a mock time service:
-        let (_tick_sender, tick_receiver) = mpsc::channel::<()>(0);
-        let timer_client = create_timer_incoming(tick_receiver, spawner.clone()).unwrap();
 
         let (local_sender, mut relay_receiver) = mpsc::channel::<Vec<u8>>(0);
         let (mut relay_sender, local_receiver) = mpsc::channel::<Vec<u8>>(0);

--- a/components/relay/src/client/mod.rs
+++ b/components/relay/src/client/mod.rs
@@ -1,3 +1,2 @@
 pub mod client_connector;
 pub mod client_listener;
-pub mod access_control;

--- a/components/relay/src/server/mod.rs
+++ b/components/relay/src/server/mod.rs
@@ -4,7 +4,7 @@ use futures::{future, FutureExt, TryFutureExt, stream, Stream, StreamExt, Sink, 
 use futures::channel::mpsc;
 use futures::task::{Spawn, SpawnExt};
 
-use timer::{TimerTick, TimerClient};
+use timer::TimerClient;
 use crypto::identity::PublicKey;
 use common::futures_compat::send_to_sink;
 
@@ -79,13 +79,11 @@ enum RelayServerError {
 }
 
 
-fn handle_accept<MT,KT,MA,KA,TCL,TS>(listeners: &mut HashMap<PublicKey, Listener<MT,KT>>,
+fn handle_accept<MT,KT,MA,KA,TCL>(listeners: &mut HashMap<PublicKey, Listener<MT,KT>>,
                             acceptor_public_key: PublicKey,
                             incoming_accept: IncomingAccept<MA,KA>,
                             // TODO: This should be a oneshot:
                             tunnel_closed_sender: TCL,
-                            timer_stream: TS,
-                            keepalive_ticks: usize,
                             mut spawner: impl Spawn) -> Result<(), RelayServerError>
 where
     MT: Stream<Item=Vec<u8>> + Unpin + Send + 'static,
@@ -93,14 +91,13 @@ where
     MA: Stream<Item=Vec<u8>> + Unpin + Send + 'static,
     KA: Sink<SinkItem=Vec<u8>,SinkError=()> + Unpin + Send + 'static,
     TCL: Sink<SinkItem=TunnelClosed, SinkError=()> + Unpin + Send + 'static,
-    TS: Stream<Item=TimerTick> + Unpin + Send + 'static,
 {
     let listener = match listeners.get_mut(&acceptor_public_key) {
         Some(listener) => listener,
         None => return Err(RelayServerError::ListeningNotInProgress),
     };
     let IncomingAccept {mut receiver, mut sender, accept_public_key} = incoming_accept;
-    let mut conn_pair = 
+    let conn_pair = 
         match listener.half_tunnels.remove(&accept_public_key) {
             Some(HalfTunnel {conn_pair, ..}) => conn_pair,
             None => return Err(RelayServerError::NoPendingHalfTunnel),
@@ -172,7 +169,6 @@ where
         let c_event_sender = event_sender
             .clone()
             .sink_map_err(|_| ());
-        let mut c_timer_client = timer_client.clone();
         match relay_server_event {
             RelayServerEvent::IncomingConn(incoming_conn) => {
                 let IncomingConn {public_key, inner} = incoming_conn;
@@ -181,8 +177,6 @@ where
                         if listeners.contains_key(&public_key) {
                             continue; // Discard Listen connection
                         }
-                        let timer_stream = await!(c_timer_client.request_timer_stream())
-                            .map_err(|_| RelayServerError::RequestTimerStreamError)?;
 
                         let sender = incoming_listen.sender;
                         let receiver = incoming_listen.receiver;
@@ -217,14 +211,10 @@ where
                     IncomingConnInner::Accept(incoming_accept) => {
                         let tunnel_closed_sender = c_event_sender
                             .with(|tunnel_closed| future::ready(Ok(RelayServerEvent::TunnelClosed(tunnel_closed))));
-                        let timer_stream = await!(c_timer_client.request_timer_stream())
-                            .map_err(|_| RelayServerError::RequestTimerStreamError)?;
                         let _ = handle_accept(&mut listeners,
                                       public_key.clone(),
                                       incoming_accept,
                                       tunnel_closed_sender,
-                                      timer_stream,
-                                      keepalive_ticks,
                                       spawner.clone());
                     },
                     IncomingConnInner::Connect(incoming_connect) => {

--- a/components/relay/src/server/mod.rs
+++ b/components/relay/src/server/mod.rs
@@ -4,8 +4,6 @@ use futures::{future, FutureExt, TryFutureExt, stream, Stream, StreamExt, Sink, 
 use futures::channel::mpsc;
 use futures::task::{Spawn, SpawnExt};
 
-use keepalive::keepalive_channel;
-
 use timer::{TimerTick, TimerClient};
 use crypto::identity::PublicKey;
 use common::futures_compat::send_to_sink;


### PR DESCRIPTION
- Implemented FutTransform trait (A trait more generic than the ConnTransform)
- Removed Connector trait in favor of FutTransform.

- DummyConnector implements FutTransform.
- offst-keepalive implements FutTransform
- offst-secure-channel implements FutTransform
- offst-channeler uses FutTransform as connectors, encryption and keepalive.

- offst-relay: removed offst-keepalive dependency.
- offst-channeler: Removed offst-relay and offst-secure-channel dependencies.