### PR TITLE
Unify "TODO:"s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     - travis/trusty/pre/cargo-config.sh
     - travis/trusty/pre/capnp.sh
     - cargo fmt --all -- --check
-      # TOOD Enable these two lints when clippy bugs are solved:
+      # TODO: Enable these two lints when clippy bugs are solved:
     - cargo clippy -- -A clippy::needless_lifetimes -A clippy::identity_conversion
       # We add target dir so that kcov can find the test files to run:
     - cargo test --target ${TARGET}
@@ -62,7 +62,7 @@ matrix:
     rust: nightly-2019-05-12
     before_script:
     # We install vcredist2010 as a requirement for the yasm assembler (Used for ring compilation)
-    - choco install vcredist2010 capnproto strawberryperl 
+    - choco install vcredist2010 capnproto strawberryperl
     - mkdir -p $HOME/install/yasm
     - curl -o $HOME/install/yasm/yasm.exe https://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe
     - export PATH=$HOME/install/yasm:$PATH
@@ -88,5 +88,3 @@ branches:
     # Ruby regex to match tags. Required, or travis won't trigger deploys when
     # a new tag is pushed. Version tags should be of the form: v0.1.0
     - /^v\d+\.\d+\.\d+.*$/
-
-

--- a/components/bin/src/stindexlib.rs
+++ b/components/bin/src/stindexlib.rs
@@ -25,7 +25,7 @@ use net::{NetConnector, TcpListener};
 use proto::file::identity::load_identity_from_file;
 use proto::file::index_server::{load_trusted_servers, IndexServerDirectoryError};
 
-// TODO; Maybe take as a command line argument in the future?
+// TODO: Maybe take as a command line argument in the future?
 /// Maximum amount of concurrent encrypted channel set-ups.
 /// We set this number to avoid DoS from half finished encrypted channel negotiations.
 pub const MAX_CONCURRENT_ENCRYPT: usize = 0x200;

--- a/components/bin/src/strelaylib.rs
+++ b/components/bin/src/strelaylib.rs
@@ -22,7 +22,7 @@ use timer::create_timer;
 
 use proto::file::identity::load_identity_from_file;
 
-// TODO; Maybe take as a command line argument in the future?
+// TODO: Maybe take as a command line argument in the future?
 /// Maximum amount of concurrent encrypted channel set-ups.
 /// We set this number to avoid DoS from half finished encrypted channel negotiations.
 pub const MAX_CONCURRENT_ENCRYPT: usize = 0x200;

--- a/components/channeler/src/connect_pool.rs
+++ b/components/channeler/src/connect_pool.rs
@@ -103,7 +103,7 @@ where
     C: FutTransform<Input = (RA, PublicKey), Output = Option<RawConn>> + Clone,
     ET: FutTransform<Input = (PublicKey, RawConn), Output = Option<RawConn>> + Clone,
 {
-    // TODO; How to remove this Box::pin?
+    // TODO: How to remove this Box::pin?
     let connect_fut = Box::pin(async move {
         let raw_conn = await!(client_connector.transform((address, friend_public_key.clone())))?;
         await!(encrypt_transform.transform((friend_public_key.clone(), raw_conn)))

--- a/components/funder/src/token_channel.rs
+++ b/components/funder/src/token_channel.rs
@@ -254,7 +254,7 @@ where
                     }
                     SetDirection::Outgoing(friend_move_token) => {
                         let tc_outgoing = TcOutgoing {
-                            mutual_credit: self.get_mutual_credit().clone(), // TODO; Remove this clone()
+                            mutual_credit: self.get_mutual_credit().clone(), // TODO: Remove this clone()
                             move_token_out: friend_move_token.clone(),
                             opt_prev_move_token_in: self
                                 .get_last_incoming_move_token_hashed()

--- a/components/index_server/src/verifier/simple_verifier.rs
+++ b/components/index_server/src/verifier/simple_verifier.rs
@@ -20,7 +20,7 @@ where
 {
     #[allow(unused)]
     pub fn new(ticks_to_live: usize, rng: R) -> Self {
-        // TODO(Security): Make sure that we don't have an off-by-one here with the decision to have
+        // TODO: Security: Make sure that we don't have an off-by-one here with the decision to have
         // one ticks_to_live value for both `hash_clock` and `ratchet_pool`.
 
         assert!(ticks_to_live > 0);

--- a/components/node/src/connect/node_connection/report.rs
+++ b/components/node/src/connect/node_connection/report.rs
@@ -13,7 +13,7 @@ pub struct AppReport {
 }
 
 impl AppReport {
-    // TODO; Should this be private?
+    // TODO: Should this be private?
     pub(super) fn new(
         report_client: StateClient<BatchMutable<NodeReport>, Vec<NodeReportMutation>>,
     ) -> Self {

--- a/components/node/src/connect/node_connection/send_funds.rs
+++ b/components/node/src/connect/node_connection/send_funds.rs
@@ -13,7 +13,7 @@ use proto::funder::messages::{
     UserRequestSendFunds,
 };
 
-// TODO; Different in naming convention from AppConfigError and AppRoutesError:
+// TODO: Different in naming convention from AppConfigError and AppRoutesError:
 #[derive(Debug)]
 pub enum SendFundsError {
     /// A local error occurred when trying to send funds.

--- a/components/proto/src/funder/signature_buff.rs
+++ b/components/proto/src/funder/signature_buff.rs
@@ -144,7 +144,7 @@ where
 
     hash_buff.extend_from_slice(&move_token.old_token);
 
-    // TODO; Use CanonicalSerialize instead here:
+    // TODO: Use CanonicalSerialize instead here:
     hash_buff
         .write_u64::<BigEndian>(usize_to_u64(move_token.operations.len()).unwrap())
         .unwrap();

--- a/components/relay/src/client/client_connector.rs
+++ b/components/relay/src/client/client_connector.rs
@@ -50,7 +50,7 @@ where
         let from_tunnel_receiver = receiver;
         let to_tunnel_sender = sender;
 
-        // TODO; Do something about the unwrap here:
+        // TODO: Do something about the unwrap here:
         // Maybe change ConnTransform trait to allow force returning something that is not None?
         let (user_to_tunnel, user_from_tunnel) = await!(self
             .keepalive_transform

--- a/components/relay/src/server/net_server.rs
+++ b/components/relay/src/server/net_server.rs
@@ -127,7 +127,7 @@ where
         spawner.clone(),
     );
 
-    // TODO; How to get rid of Box::pin() here?
+    // TODO: How to get rid of Box::pin() here?
     let incoming_ver_conns = Box::pin(incoming_raw_conns.then(move |raw_conn| {
         // TODO: A more efficient way to do this?
         // We seem to have to clone version_transform for every connection


### PR DESCRIPTION
8a69d1d7a1e1a240a6d1fa5de9163d5c7fdf47b3, last commit in #198 , introduced a typo. This PR fixes it, and changes all `TODO;` to `TODO:`.