### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
         packages:
         - gcc-6
         - g++-6
+        - moreutils
         sources:
         - ubuntu-toolchain-r-test
     script:
@@ -43,7 +44,7 @@ matrix:
       # We add target dir so that kcov can find the test files to run:
     - cargo test --target ${TARGET}
     - travis/trusty/post/kcov/try-install.sh
-    - travis/trusty/post/kcov/run.sh
+    - travis_wait 30 travis/trusty/post/kcov/run.sh
 
   - env: TARGET=x86_64-apple-darwin
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       # TODO: Enable these two lints when clippy bugs are solved:
     - cargo clippy -- -A clippy::needless_lifetimes -A clippy::identity_conversion
       # We add target dir so that kcov can find the test files to run:
-    - cargo test --target ${TARGET}
+    - cargo test --target ${TARGET} -- --nocapture
     - travis/trusty/post/kcov/try-install.sh
     - travis/trusty/post/kcov/run.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       # We add target dir so that kcov can find the test files to run:
     - cargo test --target ${TARGET}
     - travis/trusty/post/kcov/try-install.sh
-    - travis_wait 30 travis/trusty/post/kcov/run.sh
+    - travis/trusty/post/kcov/run.sh
 
   - env: TARGET=x86_64-apple-darwin
     os: osx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Offst
 
-[![Build Status](https://travis-ci.com/freedomlayer/offst.svg?branch=master)](https://travis-ci.com/freedomlayer/offst)
+[![Build Status](https://travis-ci.com/freedomlayer/offst.svg?branch=master)](https://travis-ci.com/freedomlayer/offst/branches)
 [![codecov](https://codecov.io/gh/freedomlayer/offst/branch/master/graph/badge.svg)](https://codecov.io/gh/freedomlayer/offst)
 [![Documentation Status](https://readthedocs.org/projects/offst/badge/?version=latest)](https://offst.readthedocs.io/en/latest/?badge=latest)
 [![Gitter chat](https://badges.gitter.im/freedomlayer/offst.svg)](https://gitter.im/freedomlayer/offst)
@@ -31,7 +31,7 @@ Warning: Offst is still a work in progress, and is not yet ready for use in prod
 - Install [Rust](https://www.rust-lang.org/tools/install).
 - Install [capnproto](https://capnproto.org):
   - On Ubuntu, run: `sudo apt install capnproto`
-  - On MacOS, run: `brew install canpnp` 
+  - On MacOS, run: `brew install canpnp`
 
 ### Pinned toolchain version
 

--- a/travis/trusty/post/kcov/run.sh
+++ b/travis/trusty/post/kcov/run.sh
@@ -4,12 +4,13 @@
 
 exes=$(find target/${TARGET}/debug -maxdepth 1 -executable -type f)
 for exe in ${exes}; do
+    echo ">>> kcov: " ${exe}
     ${HOME}/install/kcov-${TARGET}/bin/kcov \
         --verify \
         --exclude-path=/usr/include \
         --include-pattern="components" \
         target/kcov \
-        ${exe}
+        ${exe} | ts '[%M:%.S]'
 done
 
 # Automatically reads from CODECOV_TOKEN environment variable:

--- a/travis/trusty/post/kcov/run.sh
+++ b/travis/trusty/post/kcov/run.sh
@@ -2,6 +2,15 @@
 
 # CODECOV_TOKEN Must be set at this point.
 
+wait_forever() {
+    while :
+    do
+        echo .
+        sleep 60
+    done
+}
+wait_forever &
+
 exes=$(find target/${TARGET}/debug -maxdepth 1 -executable -type f)
 for exe in ${exes}; do
     echo ">>> kcov: " ${exe}

--- a/travis/trusty/post/kcov/run.sh
+++ b/travis/trusty/post/kcov/run.sh
@@ -5,21 +5,21 @@
 wait_forever() {
     while :
     do
-        echo .
-        sleep 60
+        echo -n .
+        sleep 10
     done
 }
 wait_forever &
 
 exes=$(find target/${TARGET}/debug -maxdepth 1 -executable -type f)
 for exe in ${exes}; do
-    echo ">>> kcov: " ${exe}
+    echo ">>> kcov: " ${exe} | ts '[%H:%M:%.S]'
     ${HOME}/install/kcov-${TARGET}/bin/kcov \
         --verify \
-        --exclude-path=/usr/include \
+        --exclude-pattern=/.cargo,/usr/lib,/usr/include \
         --include-pattern="components" \
         target/kcov \
-        ${exe} | ts '[%M:%.S]'
+        ${exe} --nocapture | ts '[%H:%M:%.S]'
 done
 
 # Automatically reads from CODECOV_TOKEN environment variable:


### PR DESCRIPTION
Closes #206 

- kcov is allowed to work silently for 30 minutes now (it worked fine on 20, too)
- kcov output is being timestamped, to see how long each action takes
- Travis badge links to `<Travis>/branches`