### PR TITLE
Refactor friend state

### DIFF
--- a/components/funder/src/handler/canceler.rs
+++ b/components/funder/src/handler/canceler.rs
@@ -125,7 +125,7 @@ pub fn cancel_local_pending_transactions<B, R>(
 
     let token_channel = match &friend.channel_status {
         ChannelStatus::Inconsistent(_) => unreachable!(),
-        ChannelStatus::Consistent(token_channel) => token_channel,
+        ChannelStatus::Consistent(channel_consistent) => &channel_consistent.token_channel,
     };
 
     // Mark all pending requests to this friend as errors.
@@ -183,7 +183,11 @@ pub fn cancel_pending_requests<B, R>(
     R: CryptoRandom,
 {
     let friend = m_state.state().friends.get(friend_public_key).unwrap();
-    let mut pending_requests = friend.pending_requests.clone();
+    let channel_consistent = match &friend.channel_status {
+        ChannelStatus::Inconsistent(_) => unreachable!(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent,
+    };
+    let mut pending_requests = channel_consistent.pending_requests.clone();
 
     while let Some(pending_request) = pending_requests.pop_front() {
         let friend_mutation = FriendMutation::PopFrontPendingRequest;
@@ -231,7 +235,11 @@ pub fn cancel_pending_user_requests<B, R>(
     R: CryptoRandom,
 {
     let friend = m_state.state().friends.get(&friend_public_key).unwrap();
-    let mut pending_user_requests = friend.pending_user_requests.clone();
+    let channel_consistent = match &friend.channel_status {
+        ChannelStatus::Inconsistent(_) => unreachable!(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent,
+    };
+    let mut pending_user_requests = channel_consistent.pending_user_requests.clone();
 
     while let Some(pending_user_request) = pending_user_requests.pop_front() {
         let friend_mutation = FriendMutation::PopFrontPendingUserRequest;

--- a/components/funder/src/handler/handle_friend.rs
+++ b/components/funder/src/handler/handle_friend.rs
@@ -504,7 +504,7 @@ fn handle_move_token_error<B, R>(
 {
     let friend = m_state.state().friends.get(remote_public_key).unwrap();
     let token_channel = match &friend.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel,
+        ChannelStatus::Consistent(channel_consistent) => &channel_consistent.token_channel,
         ChannelStatus::Inconsistent(_) => unreachable!(),
     };
     let opt_last_incoming_move_token = token_channel.get_last_incoming_move_token_hashed().cloned();
@@ -686,7 +686,7 @@ where
     }?;
 
     let token_channel = match &friend.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel,
+        ChannelStatus::Consistent(channel_consistent) => &channel_consistent.token_channel,
         ChannelStatus::Inconsistent(channel_inconsistent) => {
             let local_reset_terms = channel_inconsistent.local_reset_terms.clone();
             try_reset_channel(
@@ -767,7 +767,8 @@ where
     let friend = m_state.state().friends.get(remote_public_key).unwrap();
     let (should_send_outgoing, new_local_reset_terms, opt_last_incoming_move_token) =
         match &friend.channel_status {
-            ChannelStatus::Consistent(token_channel) => {
+            ChannelStatus::Consistent(channel_consistent) => {
+                let token_channel = &channel_consistent.token_channel;
                 if !token_channel.is_outgoing() {
                     return Err(HandleFriendError::InconsistencyWhenTokenOwned);
                 }

--- a/components/funder/src/handler/handle_friend.rs
+++ b/components/funder/src/handler/handle_friend.rs
@@ -750,22 +750,12 @@ where
         None => Err(HandleFriendError::FriendDoesNotExist),
     }?;
 
-    // Cancel all pending requests to this friend:
-    cancel_pending_requests(
-        m_state,
-        send_commands,
-        outgoing_control,
-        rng,
-        remote_public_key,
-    );
-    cancel_pending_user_requests(m_state, outgoing_control, rng, remote_public_key);
-
     // Save remote incoming inconsistency details:
     let new_remote_reset_terms = remote_reset_terms;
 
     // Obtain information about our reset terms:
     let friend = m_state.state().friends.get(remote_public_key).unwrap();
-    let (should_send_outgoing, new_local_reset_terms, opt_last_incoming_move_token) =
+    let (channel_was_consistent, new_local_reset_terms, opt_last_incoming_move_token) =
         match &friend.channel_status {
             ChannelStatus::Consistent(channel_consistent) => {
                 let token_channel = &channel_consistent.token_channel;
@@ -785,6 +775,18 @@ where
             ),
         };
 
+    if channel_was_consistent {
+        // Cancel all pending requests to this friend:
+        cancel_pending_requests(
+            m_state,
+            send_commands,
+            outgoing_control,
+            rng,
+            remote_public_key,
+        );
+        cancel_pending_user_requests(m_state, outgoing_control, rng, remote_public_key);
+    }
+
     // Keep outgoing InconsistencyError message details in memory:
     let channel_inconsistent = ChannelInconsistent {
         opt_last_incoming_move_token,
@@ -797,7 +799,7 @@ where
     m_state.mutate(funder_mutation);
 
     // Send an outgoing inconsistency message if required:
-    if should_send_outgoing {
+    if channel_was_consistent {
         send_commands.set_try_send(remote_public_key);
     }
     Ok(())

--- a/components/funder/src/handler/handle_liveness.rs
+++ b/components/funder/src/handler/handle_liveness.rs
@@ -150,7 +150,7 @@ mod tests {
         // Make sure that our side of the token channel is outgoing:
         let friend = state.friends.get(&remote_pk).unwrap();
         let token_channel = match &friend.channel_status {
-            ChannelStatus::Consistent(token_channel) => token_channel,
+            ChannelStatus::Consistent(channel_consistent) => &channel_consistent.token_channel,
             _ => unreachable!(),
         };
         assert!(token_channel.is_outgoing());

--- a/components/funder/src/handler/sender.rs
+++ b/components/funder/src/handler/sender.rs
@@ -404,12 +404,15 @@ where
     // Check if update to remote_max_debt is required:
     match &friend.channel_status {
         ChannelStatus::Consistent(channel_consistent) => {
-            if friend.wanted_remote_max_debt != channel_consistent.token_channel.get_remote_max_debt() {
+            if friend.wanted_remote_max_debt
+                != channel_consistent.token_channel.get_remote_max_debt()
+            {
                 return true;
             }
 
             // Open or close requests is needed:
-            let local_requests_status = &channel_consistent.token_channel
+            let local_requests_status = &channel_consistent
+                .token_channel
                 .get_mutual_credit()
                 .state()
                 .requests_status
@@ -419,9 +422,10 @@ where
                 return true;
             }
 
-            if !channel_consistent.pending_backwards_ops.is_empty() ||  
-               !channel_consistent.pending_requests.is_empty() ||
-               !channel_consistent.pending_user_requests.is_empty() {
+            if !channel_consistent.pending_backwards_ops.is_empty()
+                || !channel_consistent.pending_requests.is_empty()
+                || !channel_consistent.pending_user_requests.is_empty()
+            {
                 return true;
             }
         }
@@ -609,7 +613,8 @@ where
     };
 
     // Open or close requests is needed:
-    let local_requests_status = &channel_consistent.token_channel
+    let local_requests_status = &channel_consistent
+        .token_channel
         .get_mutual_credit()
         .state()
         .requests_status

--- a/components/funder/src/handler/tests/pair_basic.rs
+++ b/components/funder/src/handler/tests/pair_basic.rs
@@ -511,7 +511,9 @@ async fn task_handler_pair_basic<'a>(
     // Checking the current requests status on the mutual credit:
     let friend2 = state1.friends.get(&pk2).unwrap();
     let mutual_credit_state = match &friend2.channel_status {
-        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent.token_channel.get_mutual_credit().state()
+        }
         _ => unreachable!(),
     };
     assert_eq!(
@@ -607,7 +609,9 @@ async fn task_handler_pair_basic<'a>(
     // Checking the current requests status on the mutual credit for Node1:
     let friend2 = state1.friends.get(&pk2).unwrap();
     let mutual_credit_state = match &friend2.channel_status {
-        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent.token_channel.get_mutual_credit().state()
+        }
         _ => unreachable!(),
     };
     assert!(mutual_credit_state.requests_status.local.is_open());
@@ -616,7 +620,9 @@ async fn task_handler_pair_basic<'a>(
     // Checking the current requests status on the mutual credit for Node2:
     let friend1 = state2.friends.get(&pk1).unwrap();
     let mutual_credit_state = match &friend1.channel_status {
-        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent.token_channel.get_mutual_credit().state()
+        }
         _ => unreachable!(),
     };
     assert!(!mutual_credit_state.requests_status.local.is_open());
@@ -834,7 +840,9 @@ async fn task_handler_pair_basic<'a>(
     // Current balance from Node1 point of view:
     let friend2 = state1.friends.get(&pk2).unwrap();
     let mutual_credit_state = match &friend2.channel_status {
-        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent.token_channel.get_mutual_credit().state()
+        }
         _ => unreachable!(),
     };
     assert_eq!(mutual_credit_state.balance.balance, 20);
@@ -844,7 +852,9 @@ async fn task_handler_pair_basic<'a>(
     // Current balance from Node2 point of view:
     let friend1 = state2.friends.get(&pk1).unwrap();
     let mutual_credit_state = match &friend1.channel_status {
-        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent.token_channel.get_mutual_credit().state()
+        }
         _ => unreachable!(),
     };
     assert_eq!(mutual_credit_state.balance.balance, -20);

--- a/components/funder/src/handler/tests/pair_basic.rs
+++ b/components/funder/src/handler/tests/pair_basic.rs
@@ -391,8 +391,9 @@ async fn task_handler_pair_basic<'a>(
 
     let friend2 = state1.friends.get(&pk2).unwrap();
     let remote_max_debt = match &friend2.channel_status {
-        ChannelStatus::Consistent(token_channel) => {
-            token_channel
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent
+                .token_channel
                 .get_mutual_credit()
                 .state()
                 .balance
@@ -404,8 +405,9 @@ async fn task_handler_pair_basic<'a>(
 
     let friend1 = state2.friends.get(&pk1).unwrap();
     let local_max_debt = match &friend1.channel_status {
-        ChannelStatus::Consistent(token_channel) => {
-            token_channel
+        ChannelStatus::Consistent(channel_consistent) => {
+            channel_consistent
+                .token_channel
                 .get_mutual_credit()
                 .state()
                 .balance
@@ -509,7 +511,7 @@ async fn task_handler_pair_basic<'a>(
     // Checking the current requests status on the mutual credit:
     let friend2 = state1.friends.get(&pk2).unwrap();
     let mutual_credit_state = match &friend2.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
         _ => unreachable!(),
     };
     assert_eq!(
@@ -605,7 +607,7 @@ async fn task_handler_pair_basic<'a>(
     // Checking the current requests status on the mutual credit for Node1:
     let friend2 = state1.friends.get(&pk2).unwrap();
     let mutual_credit_state = match &friend2.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
         _ => unreachable!(),
     };
     assert!(mutual_credit_state.requests_status.local.is_open());
@@ -614,7 +616,7 @@ async fn task_handler_pair_basic<'a>(
     // Checking the current requests status on the mutual credit for Node2:
     let friend1 = state2.friends.get(&pk1).unwrap();
     let mutual_credit_state = match &friend1.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
         _ => unreachable!(),
     };
     assert!(!mutual_credit_state.requests_status.local.is_open());
@@ -832,7 +834,7 @@ async fn task_handler_pair_basic<'a>(
     // Current balance from Node1 point of view:
     let friend2 = state1.friends.get(&pk2).unwrap();
     let mutual_credit_state = match &friend2.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
         _ => unreachable!(),
     };
     assert_eq!(mutual_credit_state.balance.balance, 20);
@@ -842,7 +844,7 @@ async fn task_handler_pair_basic<'a>(
     // Current balance from Node2 point of view:
     let friend1 = state2.friends.get(&pk1).unwrap();
     let mutual_credit_state = match &friend1.channel_status {
-        ChannelStatus::Consistent(token_channel) => token_channel.get_mutual_credit().state(),
+        ChannelStatus::Consistent(channel_consistent) => channel_consistent.token_channel.get_mutual_credit().state(),
         _ => unreachable!(),
     };
     assert_eq!(mutual_credit_state.balance.balance, -20);

--- a/components/funder/src/handler/tests/pair_inconsistency.rs
+++ b/components/funder/src/handler/tests/pair_inconsistency.rs
@@ -342,9 +342,9 @@ async fn task_handler_pair_inconsistency<'a>(
 
     let friend2 = state1.friends.get(&pk2).unwrap();
     match &friend2.channel_status {
-        ChannelStatus::Consistent(token_channel) => {
+        ChannelStatus::Consistent(channel_consistent) => {
             assert_eq!(
-                token_channel.get_mutual_credit().state().balance.balance,
+                channel_consistent.token_channel.get_mutual_credit().state().balance.balance,
                 10i128
             );
         }

--- a/components/funder/src/handler/tests/pair_inconsistency.rs
+++ b/components/funder/src/handler/tests/pair_inconsistency.rs
@@ -344,7 +344,12 @@ async fn task_handler_pair_inconsistency<'a>(
     match &friend2.channel_status {
         ChannelStatus::Consistent(channel_consistent) => {
             assert_eq!(
-                channel_consistent.token_channel.get_mutual_credit().state().balance.balance,
+                channel_consistent
+                    .token_channel
+                    .get_mutual_credit()
+                    .state()
+                    .balance
+                    .balance,
                 10i128
             );
         }

--- a/components/funder/src/handler/utils.rs
+++ b/components/funder/src/handler/utils.rs
@@ -28,8 +28,9 @@ where
     for (friend_public_key, friend) in &state.friends {
         match &friend.channel_status {
             ChannelStatus::Inconsistent(_) => continue,
-            ChannelStatus::Consistent(token_channel) => {
-                if token_channel
+            ChannelStatus::Consistent(channel_consistent) => {
+                if channel_consistent
+                    .token_channel
                     .get_mutual_credit()
                     .state()
                     .pending_transactions
@@ -55,8 +56,9 @@ where
     for (_friend_public_key, friend) in &state.friends {
         match &friend.channel_status {
             ChannelStatus::Inconsistent(_) => continue,
-            ChannelStatus::Consistent(token_channel) => {
-                if let Some(pending_transaction) = token_channel
+            ChannelStatus::Consistent(channel_consistent) => {
+                if let Some(pending_transaction) = channel_consistent
+                    .token_channel
                     .get_mutual_credit()
                     .state()
                     .pending_transactions
@@ -87,7 +89,7 @@ where
     // Make sure that the channel is consistent:
     let token_channel = match &friend.channel_status {
         ChannelStatus::Inconsistent(_) => return false,
-        ChannelStatus::Consistent(token_channel) => token_channel,
+        ChannelStatus::Consistent(channel_consistent) => &channel_consistent.token_channel,
     };
 
     // Make sure that the remote side has open requests:

--- a/components/funder/src/mutual_credit/types.rs
+++ b/components/funder/src/mutual_credit/types.rs
@@ -11,7 +11,7 @@ use proto::funder::messages::{PendingTransaction, RequestsStatus, TransactionSta
 pub const MAX_FUNDER_DEBT: u128 = (1 << 127) - 1;
 
 // TODO: Rename this to McIdents
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct McIdents {
     /// My public key
     pub local_public_key: PublicKey,
@@ -20,7 +20,7 @@ pub struct McIdents {
 }
 
 // TODO: Rename this to McBalance
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct McBalance {
     /// Amount of credits this side has against the remote side.
     /// The other side keeps the negation of this value.
@@ -50,7 +50,7 @@ impl McBalance {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct McPendingTransactions {
     /// Pending transactions that were opened locally and not yet completed
     pub local: ImHashMap<Uid, PendingTransaction>,
@@ -84,7 +84,7 @@ impl McRequestsStatus {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct MutualCreditState {
     /// Public identities of local and remote side
     pub idents: McIdents,
@@ -98,7 +98,7 @@ pub struct MutualCreditState {
     pub requests_status: McRequestsStatus,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct MutualCredit {
     state: MutualCreditState,
 }

--- a/components/funder/src/tests/tests.rs
+++ b/components/funder/src/tests/tests.rs
@@ -123,7 +123,7 @@ async fn task_funder_basic(test_executor: TestExecutor) {
     let pred = |report: &FunderReport<_>| {
         let friend = report.friends.get(&public_keys[1]).unwrap();
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             _ => return false,
         };
         tc_report.balance.balance == 3
@@ -133,7 +133,7 @@ async fn task_funder_basic(test_executor: TestExecutor) {
     let pred = |report: &FunderReport<_>| {
         let friend = report.friends.get(&public_keys[0]).unwrap();
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             _ => return false,
         };
         tc_report.balance.balance == -3
@@ -281,7 +281,7 @@ async fn task_funder_forward_payment(test_executor: TestExecutor) {
             Some(friend) => friend,
         };
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             _ => return false,
         };
         tc_report.balance.balance == -6 + 15
@@ -296,7 +296,7 @@ async fn task_funder_forward_payment(test_executor: TestExecutor) {
             Some(friend) => friend,
         };
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             _ => return false,
         };
 
@@ -310,7 +310,7 @@ async fn task_funder_forward_payment(test_executor: TestExecutor) {
             Some(friend) => friend,
         };
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             _ => return false,
         };
         tc_report.balance.balance == 6 - 15
@@ -438,7 +438,7 @@ async fn task_funder_payment_failure(test_executor: TestExecutor) {
             Some(friend) => friend,
         };
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             _ => return false,
         };
         tc_report.balance.balance == 8
@@ -522,7 +522,7 @@ async fn task_funder_inconsistency_basic(test_executor: TestExecutor) {
     let pred = |report: &FunderReport<_>| {
         let friend = report.friends.get(&public_keys[1]).unwrap();
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             ChannelStatusReport::Inconsistent(_) => return false,
         };
         tc_report.balance.balance == 8
@@ -533,7 +533,7 @@ async fn task_funder_inconsistency_basic(test_executor: TestExecutor) {
     let pred = |report: &FunderReport<_>| {
         let friend = report.friends.get(&public_keys[0]).unwrap();
         let tc_report = match &friend.channel_status {
-            ChannelStatusReport::Consistent(tc_report) => tc_report,
+            ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
             ChannelStatusReport::Inconsistent(_) => return false,
         };
         tc_report.balance.balance == -8

--- a/components/funder/src/tests/utils.rs
+++ b/components/funder/src/tests/utils.rs
@@ -377,7 +377,9 @@ where
                 return false;
             }
             let tc_report = match &friend.channel_status {
-                ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
+                ChannelStatusReport::Consistent(channel_consistent) => {
+                    &channel_consistent.tc_report
+                }
                 _ => return false,
             };
             tc_report.requests_status.remote == RequestsStatusReport::from(&RequestsStatus::Open)

--- a/components/funder/src/tests/utils.rs
+++ b/components/funder/src/tests/utils.rs
@@ -377,7 +377,7 @@ where
                 return false;
             }
             let tc_report = match &friend.channel_status {
-                ChannelStatusReport::Consistent(tc_report) => tc_report,
+                ChannelStatusReport::Consistent(channel_consistent) => &channel_consistent.tc_report,
                 _ => return false,
             };
             tc_report.requests_status.remote == RequestsStatusReport::from(&RequestsStatus::Open)

--- a/components/funder/src/token_channel.rs
+++ b/components/funder/src/token_channel.rs
@@ -32,27 +32,27 @@ pub enum TcMutation<B> {
     SetDirection(SetDirection<B>),
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct TcOutgoing<B> {
     pub mutual_credit: MutualCredit,
     pub move_token_out: MoveToken<B>,
     pub opt_prev_move_token_in: Option<MoveTokenHashed>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct TcIncoming {
     pub mutual_credit: MutualCredit,
     pub move_token_in: MoveTokenHashed,
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum TcDirection<B> {
     Incoming(TcIncoming),
     Outgoing(TcOutgoing<B>),
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct TokenChannel<B> {
     direction: TcDirection<B>,
 }

--- a/components/proto/src/report/convert.rs
+++ b/components/proto/src/report/convert.rs
@@ -37,7 +37,9 @@ where
 
     let tc_report = match &friend_report.channel_status {
         ChannelStatusReport::Inconsistent(_) => return (0, 0),
-        ChannelStatusReport::Consistent(tc_report) => tc_report,
+        ChannelStatusReport::Consistent(channel_consistent_report) => {
+            &channel_consistent_report.tc_report
+        }
     };
 
     let balance = &tc_report.balance;

--- a/components/proto/src/schema/report.capnp
+++ b/components/proto/src/schema/report.capnp
@@ -98,11 +98,18 @@ struct ChannelInconsistentReport {
         }
 }
 
+struct ChannelConsistentReport {
+        tcReport @0: TcReport;
+        numPendingRequests @1: UInt64;
+        numPendingBackwardsOps @2: UInt64;
+        numPendingUserRequests @3: UInt64;
+}
+
 
 struct ChannelStatusReport {
         union {
                 inconsistent @0: ChannelInconsistentReport;
-                consistent @1: TcReport;
+                consistent @1: ChannelConsistentReport;
         }
 }
 
@@ -136,10 +143,7 @@ struct FriendReport {
         channelStatus @6: ChannelStatusReport;
         wantedRemoteMaxDebt @7: CustomUInt128;
         wantedLocalRequestsStatus @8: RequestsStatusReport;
-        numPendingRequests @9: UInt64;
-        numPendingBackwardsOps @10: UInt64;
-        status @11: FriendStatusReport;
-        numPendingUserRequests @12: UInt64;
+        status @9: FriendStatusReport;
 }
 
 struct PkFriendReport {

--- a/components/stctrl/src/info.rs
+++ b/components/stctrl/src/info.rs
@@ -327,7 +327,9 @@ pub async fn info_friend_last_token(
 /// In case of an inconsistency we take the local reset terms to represent the balance.
 fn friend_balance(friend_report: &FriendReport) -> i128 {
     match &friend_report.channel_status {
-        ChannelStatusReport::Consistent(channel_consistent_report) => channel_consistent_report.tc_report.balance.balance,
+        ChannelStatusReport::Consistent(channel_consistent_report) => {
+            channel_consistent_report.tc_report.balance.balance
+        }
         ChannelStatusReport::Inconsistent(channel_inconsistent_report) => {
             channel_inconsistent_report.local_reset_terms_balance
         }

--- a/components/stctrl/src/info.rs
+++ b/components/stctrl/src/info.rs
@@ -202,7 +202,8 @@ fn is_consistent(friend_report: &FriendReport) -> bool {
 fn friend_channel_status(friend_report: &FriendReport) -> String {
     let mut res = String::new();
     match &friend_report.channel_status {
-        ChannelStatusReport::Consistent(tc_report) => {
+        ChannelStatusReport::Consistent(channel_consistent_report) => {
+            let tc_report = &channel_consistent_report.tc_report;
             res += "C: ";
             let local_requests_str = requests_status_str(&tc_report.requests_status.local);
             let remote_requests_str = requests_status_str(&tc_report.requests_status.remote);
@@ -326,7 +327,7 @@ pub async fn info_friend_last_token(
 /// In case of an inconsistency we take the local reset terms to represent the balance.
 fn friend_balance(friend_report: &FriendReport) -> i128 {
     match &friend_report.channel_status {
-        ChannelStatusReport::Consistent(tc_report) => tc_report.balance.balance,
+        ChannelStatusReport::Consistent(channel_consistent_report) => channel_consistent_report.tc_report.balance.balance,
         ChannelStatusReport::Inconsistent(channel_inconsistent_report) => {
             channel_inconsistent_report.local_reset_terms_balance
         }

--- a/components/test/src/cli_tests/basic_cli.rs
+++ b/components/test/src/cli_tests/basic_cli.rs
@@ -10,8 +10,7 @@ use stctrl::config::{
     AddFriendCmd, AddIndexCmd, AddRelayCmd, CloseFriendCmd, ConfigCmd, DisableFriendCmd,
     EnableFriendCmd, OpenFriendCmd, SetFriendMaxDebtCmd, SetFriendRateCmd,
 };
-// use stctrl::funds::{FundsCmd, PayInvoiceCmd, SendFundsCmd};
-// use stctrl::info::VerifyTokenCmd;
+
 use stctrl::buyer::{BuyerCmd, BuyerError, PayInvoiceCmd, PaymentStatusCmd};
 use stctrl::info::{BalanceCmd, ExportTicketCmd, FriendLastTokenCmd, FriendsCmd, InfoCmd};
 use stctrl::seller::{CancelInvoiceCmd, CommitInvoiceCmd, CreateInvoiceCmd, SellerCmd};

--- a/components/test/src/cli_tests/basic_cli.rs
+++ b/components/test/src/cli_tests/basic_cli.rs
@@ -585,8 +585,8 @@ fn pay_invoice(stctrl_setup: &StCtrlSetup) {
             Err(StCtrlError::BuyerError(BuyerError::NoSuitableRoute)) => {}
             Err(other_err) => {
                 error!("other_err: {:?}", other_err);
-                unreachable!(),
-            },
+                unreachable!();
+            }
         }
         thread::sleep(time::Duration::from_millis(100));
     }

--- a/components/test/src/cli_tests/basic_cli.rs
+++ b/components/test/src/cli_tests/basic_cli.rs
@@ -583,7 +583,10 @@ fn pay_invoice(stctrl_setup: &StCtrlSetup) {
         match stctrl(st_ctrl_cmd.clone(), &mut Vec::new()) {
             Ok(_) => break,
             Err(StCtrlError::BuyerError(BuyerError::NoSuitableRoute)) => {}
-            _ => unreachable!(),
+            Err(other_err) => {
+                error!("other_err: {:?}", other_err);
+                unreachable!(),
+            },
         }
         thread::sleep(time::Duration::from_millis(100));
     }


### PR DESCRIPTION
Updated Friend's data structures to make sure it is not possible to have a state where both:
- There are pending requests, backwards ops or user requests
- The channel is inconsistent.

New design:

```rust
#[derive(PartialEq, Eq, Clone, Serialize, Deserialize, Debug)]
pub struct ChannelConsistent<B> {
    /// Our mutual state with the remote side
    pub token_channel: TokenChannel<B>,
    /// A queue of requests that need to be sent to the remote friend
    pub pending_requests: ImVec<RequestSendFundsOp>,
    /// A queue of backwards operations (Response, Cancel, Commit) that need to be sent to the remote side
    /// We keep backwards op on a separate queue because those operations are not supposed to fail
    /// (While requests may fail due to lack of trust for example)
    pub pending_backwards_ops: ImVec<BackwardsOp>,
    /// Pending requests originating from the user.
    /// We care more about these requests, because those are payments that our user wants to make.
    /// This queue is bounded in size (TODO: Check this)
    pub pending_user_requests: ImVec<RequestSendFundsOp>,
}

#[allow(clippy::large_enum_variant)]
#[derive(Clone, Serialize, Deserialize, Debug)]
pub enum ChannelStatus<B> {
    Inconsistent(ChannelInconsistent),
    Consistent(ChannelConsistent<B>),
}
```