### PR TITLE
serde_derive not required in 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,6 @@ dependencies = [
  "offst-signature 0.1.0",
  "offst-timer 0.1.0",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -970,7 +969,6 @@ dependencies = [
  "offst-timer 0.1.0",
  "offst-version 0.1.0",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,6 @@ dependencies = [
  "offst-signature 0.1.0",
  "pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,6 @@ dependencies = [
  "offst-relay 0.1.0",
  "offst-timer 0.1.0",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,6 @@ dependencies = [
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.0-alpha4 (git+https://github.com/freedomlayer/ring?branch=real/version-0.13.0-alpha4)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,6 @@ dependencies = [
  "offst-mutual-from 0.1.0",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "offst-common 0.1.0",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/bin/Cargo.toml
+++ b/components/bin/Cargo.toml
@@ -40,8 +40,7 @@ node = { path = "../node", version = "0.1.0" , package = "offst-node" }
 database = { path = "../database", version = "0.1.0" , package = "offst-database" }
 
 toml = "0.4.10"
-serde_derive = "1.0.87"
-serde = "1.0.87"
+serde = {version = "1.0.87", features = ["derive"]}
 base64 = "0.10.1"
 
 log = "0.4"

--- a/components/crypto/Cargo.toml
+++ b/components/crypto/Cargo.toml
@@ -15,8 +15,7 @@ rand = "0.5"
 ring = { git = "https://github.com/freedomlayer/ring", branch = "real/version-0.13.0-alpha4" }
 untrusted = "0.6"
 
-serde = "1"
-serde_derive = "1"
+serde = {version = "1", features = ["derive"]}
 bytes = "0.4"
 base64 = "0.9"
 

--- a/components/crypto/src/lib.rs
+++ b/components/crypto/src/lib.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate common;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 pub mod dh;
 pub mod error;

--- a/components/database/Cargo.toml
+++ b/components/database/Cargo.toml
@@ -15,8 +15,7 @@ im = "12.0.0"
 
 atomicwrites = "0.2.2"
 
-serde = "1"
-serde_derive = "1"
+serde = {version = "1", features = ["derive"]}
 # serde_json = "1.0.27"
 base64 = "0.9"
 bincode = "1.1.2"

--- a/components/database/src/lib.rs
+++ b/components/database/src/lib.rs
@@ -14,7 +14,7 @@
 
 #[cfg(test)]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 mod atomic_db;
 mod database;

--- a/components/funder/Cargo.toml
+++ b/components/funder/Cargo.toml
@@ -25,8 +25,7 @@ futures-cpupool = "0.1.8"
 futures-preview = "0.3.0-alpha.16"
 
 
-serde = "1"
-serde_derive = "1"
+serde = {version = "1", features = ["derive"]}
 serde_json = "1.0.27"
 base64 = "0.9"
 
@@ -39,5 +38,3 @@ version = "1.1"
 features = ["i128"]
 
 [dev-dependencies]
-
-

--- a/components/funder/src/lib.rs
+++ b/components/funder/src/lib.rs
@@ -16,7 +16,7 @@
 #[macro_use]
 extern crate log;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 mod ephemeral;
 mod friend;

--- a/components/index_client/Cargo.toml
+++ b/components/index_client/Cargo.toml
@@ -20,6 +20,5 @@ log = "0.4"
 env_logger = "0.6.0"
 futures-preview = "0.3.0-alpha.16"
 
-serde_derive = "1.0.87"
-serde = "1.0.87"
 
+serde = {version = "1.0.87", features = ["derive"]}

--- a/components/index_client/src/lib.rs
+++ b/components/index_client/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate log;
 
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 #[macro_use]
 extern crate common;

--- a/components/node/Cargo.toml
+++ b/components/node/Cargo.toml
@@ -27,7 +27,6 @@ net = { path = "../net", version = "0.1.0" , package = "offst-net" }
 
 log = "0.4"
 futures-preview = "0.3.0-alpha.16"
-serde_derive = "1.0.87"
-serde = "1.0.87"
+serde = {version = "1.0.87", features = ["derive"]}
 
 derive_more = "0.14.0"

--- a/components/node/src/lib.rs
+++ b/components/node/src/lib.rs
@@ -16,7 +16,7 @@
 extern crate log;
 
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 mod adapters;
 mod net_node;

--- a/components/stctrl/Cargo.toml
+++ b/components/stctrl/Cargo.toml
@@ -29,8 +29,7 @@ env_logger = "0.6.0"
 futures-preview = "0.3.0-alpha.16"
 prettytable-rs = "0.8.0"
 
-serde = "1"
-serde_derive = "1"
+serde = {version = "1", features = ["derive"]}
 
 toml = "0.4.10"
 

--- a/components/stctrl/src/lib.rs
+++ b/components/stctrl/src/lib.rs
@@ -19,7 +19,7 @@ extern crate prettytable;
 // extern crate log;
 
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 mod multi_route_util;
 


### PR DESCRIPTION
#232 