### PR TITLE
Some small fixes before v0.1.1

### DIFF
--- a/components/version/src/version_prefix.rs
+++ b/components/version/src/version_prefix.rs
@@ -138,7 +138,7 @@ mod tests {
         let (_b_sender, mut b_receiver) = version_prefix_4.spawn_prefix((b_sender, b_receiver));
 
         // We expect the connection to be closed because of version mismatch:
-        a_sender.send(vec![1, 2, 3]).await.unwrap();
+        let _ = a_sender.send(vec![1, 2, 3]).await;
         assert!(b_receiver.next().await.is_none());
 
         // b_sender.send(vec![3, 2, 1]).await.unwrap();

--- a/travis/before_deploy.sh
+++ b/travis/before_deploy.sh
@@ -34,8 +34,11 @@ mk_tarball() {
         cp "target/$TARGET/release/stnode" "$staging/bin/stnode"
         cp "target/$TARGET/release/stctrl" "$staging/bin/stctrl"
 
-        # Copy the licenses and README.
-        cp {README.md,LICENSE} "$staging/"
+        # Copy README file:
+        cp README.md "$staging/"
+
+        # Copy all licenses:
+        cp LICENSE-* "$staging/"
 
         # Copy mkdocs documentation:
         cp -R "doc/." "$staging/doc/"


### PR DESCRIPTION
- Fixed copying of licenses at before_deploy.sh
- offst-version: Weakened test that sometimes fails on windows.