### PR TITLE
RequestClosePayment waits until payment is done

### DIFF
--- a/components/funder/src/handler/handle_friend.rs
+++ b/components/funder/src/handler/handle_friend.rs
@@ -9,8 +9,9 @@ use proto::app_server::messages::RelayAddress;
 use proto::funder::messages::{
     BalanceInfo, CancelSendFundsOp, ChannelerUpdateFriend, CollectSendFundsOp, CountersInfo,
     Currency, CurrencyBalance, CurrencyBalanceInfo, FriendMessage, FunderOutgoingControl, McInfo,
-    MoveTokenRequest, PendingTransaction, RequestResult, RequestSendFundsOp, ResetTerms,
-    ResponseSendFundsOp, TokenInfo, TransactionResult,
+    MoveTokenRequest, PaymentStatus, PaymentStatusSuccess, PendingTransaction, RequestResult,
+    RequestSendFundsOp, ResetTerms, ResponseClosePayment, ResponseSendFundsOp, TokenInfo,
+    TransactionResult,
 };
 use signature::signature_buff::hash_token_info;
 use signature::verify::verify_move_token;
@@ -495,7 +496,12 @@ fn handle_cancel_send_funds<B, R>(
             // We are the origin of this request, and we got a cancellation.
 
             // Update buyer transactions (requests that were originated by us):
-            remove_transaction(m_state, rng, &cancel_send_funds.request_id);
+            remove_transaction(
+                m_state,
+                outgoing_control,
+                rng,
+                &cancel_send_funds.request_id,
+            );
 
             // Inform user about the transaction failure:
             outgoing_control.push(FunderOutgoingControl::TransactionResult(
@@ -522,6 +528,7 @@ fn handle_cancel_send_funds<B, R>(
 fn handle_collect_send_funds<B, R>(
     m_state: &mut MutableFunderState<B>,
     send_commands: &mut SendCommands,
+    outgoing_control: &mut Vec<FunderOutgoingControl<B>>,
     rng: &R,
     currency: &Currency,
     collect_send_funds: CollectSendFundsOp,
@@ -548,7 +555,7 @@ fn handle_collect_send_funds<B, R>(
                 .unwrap();
 
             // Update payment status:
-            let opt_new_payment_stage = match &payment.stage {
+            let (opt_new_payment_stage, opt_payment_status) = match &payment.stage {
                 PaymentStage::NewTransactions(new_transactions) => {
                     // Create a Receipt:
                     let receipt = prepare_receipt(
@@ -558,13 +565,20 @@ fn handle_collect_send_funds<B, R>(
                         &pending_transaction,
                     );
                     let ack_uid = Uid::rand_gen(rng);
-                    Some(PaymentStage::Success((
-                        new_transactions.num_transactions.checked_sub(1).unwrap(),
-                        receipt,
-                        ack_uid,
-                    )))
+                    (
+                        Some(PaymentStage::Success((
+                            new_transactions.num_transactions.checked_sub(1).unwrap(),
+                            receipt.clone(),
+                            ack_uid.clone(),
+                        ))),
+                        Some(PaymentStatus::Success(PaymentStatusSuccess {
+                            receipt,
+                            ack_uid,
+                        })),
+                    )
                 }
                 PaymentStage::InProgress(num_transactions) => {
+                    assert!(*num_transactions > 0);
                     // Create a Receipt:
                     let receipt = prepare_receipt(
                         currency,
@@ -573,29 +587,53 @@ fn handle_collect_send_funds<B, R>(
                         &pending_transaction,
                     );
                     let ack_uid = Uid::rand_gen(rng);
-                    Some(PaymentStage::Success((
-                        num_transactions.checked_sub(1).unwrap(),
-                        receipt,
-                        ack_uid,
-                    )))
+                    (
+                        Some(PaymentStage::Success((
+                            num_transactions.checked_sub(1).unwrap(),
+                            receipt.clone(),
+                            ack_uid.clone(),
+                        ))),
+                        Some(PaymentStatus::Success(PaymentStatusSuccess {
+                            receipt: receipt,
+                            ack_uid: ack_uid,
+                        })),
+                    )
                 }
-                PaymentStage::Success((num_transactions, receipt, ack_uid)) => {
+                PaymentStage::Success((num_transactions, receipt, ack_uid)) => (
                     Some(PaymentStage::Success((
                         num_transactions.checked_sub(1).unwrap(),
                         receipt.clone(),
                         ack_uid.clone(),
-                    )))
-                }
+                    ))),
+                    Some(PaymentStatus::Success(PaymentStatusSuccess {
+                        receipt: receipt.clone(),
+                        ack_uid: ack_uid.clone(),
+                    })),
+                ),
                 PaymentStage::Canceled(_) => unreachable!(),
                 PaymentStage::AfterSuccessAck(num_transactions) => {
                     let new_num_transactions = num_transactions.checked_sub(1).unwrap();
-                    if new_num_transactions > 0 {
-                        Some(PaymentStage::AfterSuccessAck(new_num_transactions))
-                    } else {
-                        None
-                    }
+                    (
+                        if new_num_transactions > 0 {
+                            Some(PaymentStage::AfterSuccessAck(new_num_transactions))
+                        } else {
+                            None
+                        },
+                        None,
+                    )
                 }
             };
+
+            // Possibly send back a ResponseClosePayment:
+            if let Some(payment_status) = opt_payment_status {
+                let response_close_payment = ResponseClosePayment {
+                    payment_id: open_transaction.payment_id.clone(),
+                    status: payment_status,
+                };
+                outgoing_control.push(FunderOutgoingControl::ResponseClosePayment(
+                    response_close_payment,
+                ));
+            }
 
             let funder_mutation = if let Some(new_payment_stage) = opt_new_payment_stage {
                 // Update payment:
@@ -689,6 +727,7 @@ fn handle_move_token_output<B, R>(
                 handle_collect_send_funds(
                     m_state,
                     send_commands,
+                    outgoing_control,
                     rng,
                     currency,
                     incoming_collect,

--- a/components/funder/src/handler/handle_friend.rs
+++ b/components/funder/src/handler/handle_friend.rs
@@ -594,8 +594,8 @@ fn handle_collect_send_funds<B, R>(
                             ack_uid.clone(),
                         ))),
                         Some(PaymentStatus::Success(PaymentStatusSuccess {
-                            receipt: receipt,
-                            ack_uid: ack_uid,
+                            receipt,
+                            ack_uid,
                         })),
                     )
                 }

--- a/components/funder/src/handler/sender.rs
+++ b/components/funder/src/handler/sender.rs
@@ -584,7 +584,12 @@ where
         }
         None => {
             // We are the origin of this request
-            remove_transaction(m_state, outgoing_control, rng, &request_send_funds.request_id);
+            remove_transaction(
+                m_state,
+                outgoing_control,
+                rng,
+                &request_send_funds.request_id,
+            );
 
             let transaction_result = TransactionResult {
                 request_id: request_send_funds.request_id.clone(),

--- a/components/funder/src/handler/sender.rs
+++ b/components/funder/src/handler/sender.rs
@@ -584,7 +584,7 @@ where
         }
         None => {
             // We are the origin of this request
-            remove_transaction(m_state, rng, &request_send_funds.request_id);
+            remove_transaction(m_state, outgoing_control, rng, &request_send_funds.request_id);
 
             let transaction_result = TransactionResult {
                 request_id: request_send_funds.request_id.clone(),

--- a/components/proto/src/funder/messages.rs
+++ b/components/proto/src/funder/messages.rs
@@ -743,7 +743,6 @@ pub struct PaymentStatusSuccess {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PaymentStatus {
     PaymentNotFound,
-    InProgress,                    // Can not be acked
     Success(PaymentStatusSuccess), // (Receipt, ack_id)
     Canceled(Uid),                 // ack_id
 }

--- a/components/proto/src/schema/app_server.capnp
+++ b/components/proto/src/schema/app_server.capnp
@@ -188,9 +188,8 @@ struct PaymentStatusSuccess {
 struct PaymentStatus {
         union {
                 paymentNotFound @0: Void;
-                inProgress @1: Void;
-                success @2: PaymentStatusSuccess;
-                canceled @3: Uid;
+                success @1: PaymentStatusSuccess;
+                canceled @2: Uid;
         }
 }
 

--- a/components/stctrl/src/buyer.rs
+++ b/components/stctrl/src/buyer.rs
@@ -204,8 +204,12 @@ async fn buyer_pay_invoice(
         fut_list = new_fut_list;
     }
 
-    // We are not going to send anything more through this payment, so we close it:
-    let _ = app_buyer.request_close_payment(payment_id).await;
+    // TODO: We are not attempting to close the payment here, because this is going to wait
+    // until a receipt is received, but a receipt will never be received because we haven't
+    // yet produced a commit message.
+    //
+    // Possibly add some kind of nonblocking-close-payment method to app_buyer in the future?
+    // let _ = app_buyer.request_close_payment(payment_id).await;
 
     let commit = if let Some(commit) = opt_commit {
         commit
@@ -255,10 +259,6 @@ async fn buyer_payment_status(
             writeln!(writer, "Payment could not be found").map_err(|_| BuyerError::WriteError)?;
             // Remove payment file:
             fs::remove_file(&payment_path).map_err(|_| BuyerError::RemovePaymentError)?;
-            None
-        }
-        PaymentStatus::InProgress => {
-            writeln!(writer, "Payment is in progress").map_err(|_| BuyerError::WriteError)?;
             None
         }
         PaymentStatus::Success(PaymentStatusSuccess { receipt, ack_uid }) => {

--- a/components/test/src/tests/nodes_chain.rs
+++ b/components/test/src/tests/nodes_chain.rs
@@ -437,13 +437,6 @@ async fn task_nodes_chain(mut test_executor: TestExecutor) {
         .unwrap()
         .unwrap();
 
-    // Node0: Close payment (No more transactions will be sent through this payment)
-    let _ = apps[0]
-        .buyer()
-        .unwrap()
-        .request_close_payment(payment_id.clone())
-        .await
-        .unwrap();
 
     // Node0 now passes the Commit to Node4 out of band.
 
@@ -452,6 +445,14 @@ async fn task_nodes_chain(mut test_executor: TestExecutor) {
         .seller()
         .unwrap()
         .commit_invoice(commit)
+        .await
+        .unwrap();
+
+    // Node0: Close payment (No more transactions will be sent through this payment)
+    let _ = apps[0]
+        .buyer()
+        .unwrap()
+        .request_close_payment(payment_id.clone())
         .await
         .unwrap();
 
@@ -548,14 +549,6 @@ async fn task_nodes_chain(mut test_executor: TestExecutor) {
         .unwrap()
         .unwrap();
 
-    // Node5: Close payment (No more transactions will be sent through this payment)
-    let _ = apps[5]
-        .buyer()
-        .unwrap()
-        .request_close_payment(payment_id.clone())
-        .await
-        .unwrap();
-
     // Node5 now passes the Commit to Node3 out of band.
 
     // Node3: Apply the Commit
@@ -563,6 +556,14 @@ async fn task_nodes_chain(mut test_executor: TestExecutor) {
         .seller()
         .unwrap()
         .commit_invoice(commit)
+        .await
+        .unwrap();
+
+    // Node5: Close payment (No more transactions will be sent through this payment)
+    let _ = apps[5]
+        .buyer()
+        .unwrap()
+        .request_close_payment(payment_id.clone())
         .await
         .unwrap();
 

--- a/components/test/src/tests/nodes_chain.rs
+++ b/components/test/src/tests/nodes_chain.rs
@@ -437,7 +437,6 @@ async fn task_nodes_chain(mut test_executor: TestExecutor) {
         .unwrap()
         .unwrap();
 
-
     // Node0 now passes the Commit to Node4 out of band.
 
     // Node4: Apply the Commit

--- a/components/test/src/tests/resolve_inconsistency.rs
+++ b/components/test/src/tests/resolve_inconsistency.rs
@@ -93,7 +93,6 @@ where
         .await
         .unwrap();
 
-
     // Wait some time:
     advance_time(5, &mut tick_sender, &test_executor).await;
 

--- a/components/test/src/tests/resolve_inconsistency.rs
+++ b/components/test/src/tests/resolve_inconsistency.rs
@@ -82,16 +82,17 @@ where
         .unwrap()
         .unwrap();
 
+    // Node0 now passes the Commit to Node1 out of band.
+
+    // Node1: Apply the Commit
+    app_seller.commit_invoice(commit).await.unwrap();
+
     // Node0: Close payment (No more transactions will be sent through this payment)
     let _ = app_buyer
         .request_close_payment(payment_id.clone())
         .await
         .unwrap();
 
-    // Node0 now passes the Commit to Node1 out of band.
-
-    // Node1: Apply the Commit
-    app_seller.commit_invoice(commit).await.unwrap();
 
     // Wait some time:
     advance_time(5, &mut tick_sender, &test_executor).await;

--- a/components/test/src/tests/two_nodes_payment.rs
+++ b/components/test/src/tests/two_nodes_payment.rs
@@ -103,7 +103,6 @@ where
 
     // Node0 now passes the Commit to Node1 out of band.
 
-
     // Wait some time:
     advance_time(5, &mut tick_sender, &test_executor).await;
 

--- a/components/test/src/tests/two_nodes_payment.rs
+++ b/components/test/src/tests/two_nodes_payment.rs
@@ -92,6 +92,9 @@ where
         .unwrap()
         .unwrap();
 
+    // Node1: Apply the Commit
+    app_seller.commit_invoice(commit).await.unwrap();
+
     // Node0: Close payment (No more transactions will be sent through this payment)
     let _ = app_buyer
         .request_close_payment(payment_id.clone())
@@ -100,8 +103,6 @@ where
 
     // Node0 now passes the Commit to Node1 out of band.
 
-    // Node1: Apply the Commit
-    app_seller.commit_invoice(commit).await.unwrap();
 
     // Wait some time:
     advance_time(5, &mut tick_sender, &test_executor).await;


### PR DESCRIPTION
In the current implementation, `RequestClosePayment` may return an `InProgress` response.
This PR changes this behaviour: A response will be returned only when the payment is ready (with success or cancel status).