### PR TITLE
Bump async-std to 1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ jobs:
     - cargo fmt --all -- --check
       # Run clippy check:
     - cargo clippy
-    after_success:
       # We add target dir so that kcov can find the test files to run:
     - RUSTFLAGS="-C link-dead-code" cargo test --target ${TARGET}
     - ci/post/kcov/try-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
         - ubuntu-toolchain-r-test
     install:
       # Fix according to https://github.com/codecov/codecov-bash/issues/94#issuecomment-349216688
-    - pip install codecov
+    - pip install --user codecov
     script:
       # Add clippy and rustfmt:
     - rustup update

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ jobs:
         - g++-6
         sources:
         - ubuntu-toolchain-r-test
+    install:
+      # Fix according to https://github.com/codecov/codecov-bash/issues/94#issuecomment-349216688
+    - pip install codecov
     script:
       # Add clippy and rustfmt:
     - rustup update
@@ -46,6 +49,7 @@ jobs:
     - cargo fmt --all -- --check
       # Run clippy check:
     - cargo clippy
+    after_success:
       # We add target dir so that kcov can find the test files to run:
     - RUSTFLAGS="-C link-dead-code" cargo test --target ${TARGET}
     - ci/post/kcov/try-install.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "async-std"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-task 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,7 +61,7 @@ dependencies = [
  "pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "smol 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smol 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -183,6 +183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "waker-fn 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +223,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bytes"
 version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -309,43 +326,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cache-padded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "crossbeam-utils"
@@ -510,6 +501,11 @@ dependencies = [
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fastrand"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -765,22 +761,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memoffset"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "nix"
@@ -881,7 +864,7 @@ dependencies = [
 name = "offset-bin"
 version = "0.1.0"
 dependencies = [
- "async-std 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-std 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1113,7 +1096,7 @@ dependencies = [
 name = "offset-net"
 version = "0.1.0"
 dependencies = [
- "async-std 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-std 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1230,7 +1213,7 @@ dependencies = [
 name = "offset-stcompact"
 version = "0.1.0"
 dependencies = [
- "async-std 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-std 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1315,7 +1298,7 @@ dependencies = [
 name = "offset-timer"
 version = "0.1.0"
 dependencies = [
- "async-std 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-std 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,6 +1323,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "opaque-debug"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "parking"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1389,17 +1377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "piper"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "poly1305"
@@ -1676,13 +1653,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "scoped-tls-hkt"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
+name = "scoped-tls"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1781,22 +1753,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smol"
-version = "0.1.11"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-task 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blocking 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "concurrent-queue 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastrand 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "piper 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls-hkt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wepoll-binding 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wepoll-sys-stjepang 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2015,6 +1987,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "waker-fn"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,17 +2066,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-binding"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wepoll-sys 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wepoll-sys"
-version = "2.0.0"
+name = "wepoll-sys-stjepang"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2168,7 +2136,7 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-"checksum async-std 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b93c583a035d21e6d6f09adf48abfc55277bf48886406df370e5db6babe3ab98"
+"checksum async-std 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00d68a33ebc8b57800847d00787307f84a562224a14db069b0acefe4c2abbf5d"
 "checksum async-task 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 "checksum atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6a2baf2feb820299c53c7ad1cc4f5914a220a1cb76d7ce321d2522a94b54651f"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
@@ -2183,11 +2151,13 @@ dependencies = [
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-buffer 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+"checksum blocking 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9d17efb70ce4421e351d61aafd90c16a20fb5bfe339fcdc32a86816280e62ce0"
 "checksum bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 "checksum bumpalo 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+"checksum cache-padded 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24508e28c677875c380c20f4d28124fab6f8ed4ef929a1397d7b1a31e92f1005"
 "checksum capnp 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b867c15d8ff93c4d81b69c89280840f877331ef2a1fccbaf947afecc68b51a9e"
 "checksum capnpc 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2afedfc194b01c6804ad0a10c7139024b99ee3df6a39bb09bdf759067ababff"
 "checksum cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)" = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
@@ -2199,10 +2169,8 @@ dependencies = [
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cluFlock 1.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dc9a586f6ea37daf0f6154727023de0a52342bb84cf692451f09b2690e1034be"
 "checksum colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+"checksum concurrent-queue 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-"checksum crossbeam-queue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum crypto-mac 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 "checksum csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
@@ -2220,6 +2188,7 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fastrand 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b90eb1dec02087df472ab9f0db65f27edaa654a746830042688bcc2eaf68090f"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 "checksum futures-channel 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
@@ -2249,9 +2218,7 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 "checksum num-integer 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
@@ -2260,13 +2227,13 @@ dependencies = [
 "checksum object 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 "checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum parking 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4029bc3504a62d92e42f30b9095fdef73b8a0b2a06aa41ce2935143b05a1a06"
 "checksum paste 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "d508492eeb1e5c38ee696371bf7b9fc33c83d46a7d451606b96458fbbbdc2dec"
 "checksum paste-impl 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "84f328a6a63192b333fce5fbb4be79db6758a4d518dfac6d54412f1492f72d32"
 "checksum pin-project 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
 "checksum pin-project-internal 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
 "checksum pin-project-lite 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 "checksum pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-"checksum piper 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "01608bfa680dafb103f9207fa944facf572e4e3e708d10de19a0d0c3d36e5f18"
 "checksum poly1305 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
@@ -2301,8 +2268,7 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-"checksum scoped-tls-hkt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c2e9d7eaddb227e8fbaaa71136ae0e1e913ca159b86c7da82f3e8f0044ad3a63"
-"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+"checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum send_wrapper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
@@ -2314,7 +2280,7 @@ dependencies = [
 "checksum simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fea0c4611f32f4c2bac73754f22dca1f57e6c1945e0590dae4e5f2a077b92367"
 "checksum sized-chunks 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d59044ea371ad781ff976f7b06480b9f0180e834eda94114f2afb4afc12b7718"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smol 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "845f5e7db6b614a8f4f59e565c3035f0fab2f71c9537ff0119eddb60d866cae3"
+"checksum smol 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "620cbb3c6e34da57d3a248cda0cd01cd5848164dc062e764e65d06fe3ea7aed5"
 "checksum socket2 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 "checksum stream-cipher 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
@@ -2342,6 +2308,7 @@ dependencies = [
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum waker-fn 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9571542c2ce85ce642e6b58b3364da2fb53526360dfb7c211add4f5c23105ff7"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.63 (registry+https://github.com/rust-lang/crates.io-index)" = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
 "checksum wasm-bindgen-backend 0.2.63 (registry+https://github.com/rust-lang/crates.io-index)" = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
@@ -2350,8 +2317,7 @@ dependencies = [
 "checksum wasm-bindgen-macro-support 0.2.63 (registry+https://github.com/rust-lang/crates.io-index)" = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 "checksum wasm-bindgen-shared 0.2.63 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
 "checksum web-sys 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
-"checksum wepoll-binding 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "374fff4ff9701ff8b6ad0d14bacd3156c44063632d8c136186ff5967d48999a7"
-"checksum wepoll-sys 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9082a777aed991f6769e2b654aa0cb29f1c3d615daf009829b07b66c7aff6a24"
+"checksum wepoll-sys-stjepang 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd319e971980166b53e17b1026812ad66c6b54063be879eb182342b55284694"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"

--- a/ci/post/kcov/run.sh
+++ b/ci/post/kcov/run.sh
@@ -15,6 +15,10 @@ for exe in ${exes}; do
         ${exe}
 done
 
+# DEBUG: Show contents of directory, to see if a report was created:
+pwd
+ls
+
 # TODO: Change to something safer:
 # Automatically reads from CODECOV_TOKEN environment variable:
 bash <(curl -s https://codecov.io/bash)

--- a/ci/post/kcov/run.sh
+++ b/ci/post/kcov/run.sh
@@ -17,7 +17,7 @@ done
 
 # DEBUG: Show contents of directory, to see if a report was created:
 pwd
-ls
+ls -la
 
 # TODO: Change to something safer:
 # Automatically reads from CODECOV_TOKEN environment variable:

--- a/ci/post/kcov/run.sh
+++ b/ci/post/kcov/run.sh
@@ -5,7 +5,7 @@
 # See: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 set -eux -o pipefail
 
-exes=$(find target/${TARGET}/debug -maxdepth 1 -executable -type f)
+exes=$(find target/${TARGET}/debug/deps/ -maxdepth 1 -executable -type f)
 for exe in ${exes}; do
     ${HOME}/install/kcov-${TARGET}/bin/kcov \
         --verify \

--- a/components/bin/Cargo.toml
+++ b/components/bin/Cargo.toml
@@ -45,7 +45,7 @@ base64 = "0.10.1"
 log = "0.4"
 env_logger = "0.6.0"
 futures = {version = "0.3.1", features = ["thread-pool"]}
-async-std = "1.6.1"
+async-std = "1.6.2"
 
 structopt = "0.2.15"
 

--- a/components/bin/src/stindex/stindexlib.rs
+++ b/components/bin/src/stindex/stindexlib.rs
@@ -5,8 +5,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use async_std::task;
-use futures::executor::ThreadPool;
+use futures::executor::{block_on, ThreadPool};
 use futures::task::SpawnExt;
 
 use structopt::StructOpt;
@@ -27,8 +26,6 @@ use timer::create_timer;
 
 use net::{TcpConnector, TcpListener};
 
-// use proto::file::identity::load_identity_from_file;
-// use proto::file::index_server::{load_trusted_servers, IndexServerDirectoryError};
 use proto::file::{IdentityFile, IndexServerFile};
 use proto::ser_string::{deserialize_from_string, StringSerdeError};
 
@@ -130,7 +127,7 @@ pub fn stindex(st_index_cmd: StIndexCmd) -> Result<(), IndexServerBinError> {
     let ListenerClient {
         config_sender: _,
         conn_receiver: incoming_client_raw_conns,
-    } = task::block_on(client_tcp_listener.listen(lclient))
+    } = block_on(client_tcp_listener.listen(lclient))
         .map_err(|_| IndexServerBinError::ListenError)?;
 
     // Start listening to servers:
@@ -139,7 +136,7 @@ pub fn stindex(st_index_cmd: StIndexCmd) -> Result<(), IndexServerBinError> {
     let ListenerClient {
         config_sender: _,
         conn_receiver: incoming_server_raw_conns,
-    } = task::block_on(server_tcp_listener.listen(lserver))
+    } = block_on(server_tcp_listener.listen(lserver))
         .map_err(|_| IndexServerBinError::ListenError)?;
 
     // A tcp connector, Used to connect to remote servers:
@@ -161,7 +158,7 @@ pub fn stindex(st_index_cmd: StIndexCmd) -> Result<(), IndexServerBinError> {
         thread_pool,
     );
 
-    task::block_on(index_server_fut).map_err(IndexServerBinError::NetIndexServerError)?;
+    block_on(index_server_fut).map_err(IndexServerBinError::NetIndexServerError)?;
 
     Ok(())
 }

--- a/components/bin/src/stnode/stnodelib.rs
+++ b/components/bin/src/stnode/stnodelib.rs
@@ -7,11 +7,9 @@ use std::time::Duration;
 use derive_more::From;
 
 use futures::channel::mpsc;
-use futures::executor::ThreadPool;
+use futures::executor::{block_on, ThreadPool};
 use futures::task::SpawnExt;
 use futures::{FutureExt, TryFutureExt};
-
-use async_std::task;
 
 use structopt::StructOpt;
 
@@ -176,8 +174,7 @@ pub fn stnode(st_node_cmd: StNodeCmd) -> Result<(), NodeBinError> {
     let ListenerClient {
         config_sender: _config_sender,
         conn_receiver: incoming_app_raw_conns,
-    } = task::block_on(app_tcp_listener.listen(laddr)).map_err(|_| NodeBinError::ListenError)?;
-    // ^ TODO: Can we possibly use future's agnostic block_on instead?
+    } = block_on(app_tcp_listener.listen(laddr)).map_err(|_| NodeBinError::ListenError)?;
 
     let trusted_apps = FileTrustedApps::new(trusted.into());
 
@@ -210,5 +207,5 @@ pub fn stnode(st_node_cmd: StNodeCmd) -> Result<(), NodeBinError> {
         thread_pool,
     );
 
-    task::block_on(node_fut).map_err(NodeBinError::NetNodeError)
+    block_on(node_fut).map_err(NodeBinError::NetNodeError)
 }

--- a/components/bin/src/strelay/strelaylib.rs
+++ b/components/bin/src/strelay/strelaylib.rs
@@ -5,10 +5,8 @@ use std::time::Duration;
 
 use derive_more::From;
 
-use futures::executor::ThreadPool;
+use futures::executor::{block_on, ThreadPool};
 use futures::task::SpawnExt;
-
-use async_std::task;
 
 use structopt::StructOpt;
 
@@ -89,7 +87,7 @@ pub fn strelay(st_relay_cmd: StRelayCmd) -> Result<(), RelayServerBinError> {
     let ListenerClient {
         config_sender: _config_sender,
         conn_receiver: incoming_raw_conns,
-    } = task::block_on(tcp_listener.listen(laddr)).map_err(|_| RelayServerBinError::ListenError)?;
+    } = block_on(tcp_listener.listen(laddr)).map_err(|_| RelayServerBinError::ListenError)?;
 
     let relay_server_fut = net_relay_server(
         incoming_raw_conns,
@@ -100,5 +98,5 @@ pub fn strelay(st_relay_cmd: StRelayCmd) -> Result<(), RelayServerBinError> {
         thread_pool,
     );
 
-    task::block_on(relay_server_fut).map_err(RelayServerBinError::NetRelayServerError)
+    block_on(relay_server_fut).map_err(RelayServerBinError::NetRelayServerError)
 }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -12,7 +12,7 @@ proto = { path = "../proto", version = "0.1.0" , package = "offset-proto" }
 
 futures = "0.3.1"
 futures_codec = "0.4.0"
-async-std = "1.6.1"
+async-std = "1.6.2"
 
 log = "0.4"
 

--- a/components/net/src/tests.rs
+++ b/components/net/src/tests.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use futures::channel::mpsc;
-use futures::executor::ThreadPool;
+use futures::executor::{block_on, ThreadPool};
 use futures::task::Spawn;
 use futures::{SinkExt, StreamExt};
 
@@ -13,7 +13,6 @@ use crate::tcp_connector::TcpConnector;
 use crate::tcp_listener::TcpListener;
 
 use async_std::net::TcpListener as AsyncStdTcpListener;
-use async_std::task;
 
 /// Get an available port we can listen on
 async fn get_available_port_v4() -> u16 {
@@ -90,10 +89,7 @@ where
 fn test_tcp_client_server_v4() {
     // env_logger::init();
     let thread_pool = ThreadPool::new().unwrap();
-    // TODO: We have to use `task::block_on` here, otherwise the sleep() calls don't work.
-    // When we remove the sleep() calls, we will be able to remove the task::block_on and use
-    // `futures` block_on instead.
-    task::block_on(task_tcp_client_server_v4(thread_pool.clone()));
+    block_on(task_tcp_client_server_v4(thread_pool.clone()));
 }
 
 async fn task_net_connector_v4_drop_sender<S>(spawner: S)
@@ -121,8 +117,5 @@ where
 #[test]
 fn test_net_connector_v4_drop_sender() {
     let thread_pool = ThreadPool::new().unwrap();
-    // TODO: We have to use `task::block_on` here, otherwise the sleep() calls don't work.
-    // When we remove the sleep() calls, we will be able to remove the task::block_on and use
-    // `futures` block_on instead.
-    task::block_on(task_net_connector_v4_drop_sender(thread_pool.clone()));
+    block_on(task_net_connector_v4_drop_sender(thread_pool.clone()));
 }

--- a/components/stcompact/Cargo.toml
+++ b/components/stcompact/Cargo.toml
@@ -40,7 +40,7 @@ base64 = "0.10.1"
 log = "0.4"
 env_logger = "0.6.0"
 futures = {version = "0.3.1", features = ["thread-pool"]}
-async-std = "1.6.1"
+async-std = "1.6.2"
 
 structopt = "0.2.15"
 

--- a/components/stcompact/src/bin/stcompact.rs
+++ b/components/stcompact/src/bin/stcompact.rs
@@ -12,8 +12,7 @@ extern crate log;
 
 use structopt::StructOpt;
 
-use async_std::task;
-use futures::executor::ThreadPool;
+use futures::executor::{block_on, ThreadPool};
 
 use stcompact::stcompactlib::{stcompact, StCompactCmd, StCompactError};
 
@@ -22,7 +21,7 @@ fn run() -> Result<(), StCompactError> {
     let st_compact_cmd = StCompactCmd::from_args();
     let thread_pool = ThreadPool::new().map_err(|_| StCompactError::SpawnError)?;
     let file_thread_pool = ThreadPool::new().map_err(|_| StCompactError::SpawnError)?;
-    task::block_on(stcompact(st_compact_cmd, thread_pool, file_thread_pool))
+    block_on(stcompact(st_compact_cmd, thread_pool, file_thread_pool))
 }
 
 fn main() {

--- a/components/timer/Cargo.toml
+++ b/components/timer/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "0.5.4"
 
 futures = "0.3.1"
 
-async-std = {version = "1.6.1", features=["unstable"]}
+async-std = {version = "1.6.2", features=["unstable"]}
 
 common = { path = "../common", version = "0.1.0", package = "offset-common" }
 

--- a/components/timer/src/timer.rs
+++ b/components/timer/src/timer.rs
@@ -225,11 +225,9 @@ pub fn create_timer(dur: Duration, spawner: impl Spawn) -> Result<TimerClient, T
 mod tests {
     use super::*;
     use core::pin::Pin;
-    use futures::executor::{LocalPool, ThreadPool};
+    use futures::executor::{block_on, LocalPool, ThreadPool};
     use futures::future::join;
     use std::time::{Duration, Instant};
-
-    use async_std::task;
 
     #[test]
     fn test_timer_single() {
@@ -246,7 +244,7 @@ mod tests {
             )
             .unwrap();
         let wait_fut = timer_stream.take(10).collect::<Vec<TimerTick>>();
-        task::block_on(wait_fut);
+        block_on(wait_fut);
     }
 
     #[test]
@@ -264,7 +262,7 @@ mod tests {
             )
             .unwrap();
         let wait_fut = timer_stream.take(10).collect::<Vec<TimerTick>>();
-        task::block_on(wait_fut);
+        block_on(wait_fut);
 
         let timer_stream = LocalPool::new()
             .run_until(
@@ -274,7 +272,7 @@ mod tests {
             )
             .unwrap();
         let wait_fut = timer_stream.take(10).collect::<Vec<TimerTick>>();
-        task::block_on(wait_fut);
+        block_on(wait_fut);
     }
 
     #[test]
@@ -287,7 +285,7 @@ mod tests {
 
         let mut timer_streams = Vec::new();
         for _ in 0..10 {
-            let timer_stream = task::block_on(
+            let timer_stream = block_on(
                 timer_client
                     .clone()
                     .request_timer_stream("test_timer_create_multiple_streams".to_owned()),
@@ -349,7 +347,7 @@ mod tests {
             thread_pool.spawn(client_fut).unwrap();
         }
 
-        task::block_on(receiver_done).unwrap();
+        block_on(receiver_done).unwrap();
     }
 
     /////////////////////////////////////////////////////////////////////////////////////
@@ -408,7 +406,7 @@ mod tests {
         let timer_client = create_timer_incoming(tick_receiver, thread_pool.clone()).unwrap();
 
         let tick_sender = tick_sender.sink_map_err(|_| ());
-        task::block_on(task_ticks_receiver(tick_sender, timer_client)).unwrap();
+        block_on(task_ticks_receiver(tick_sender, timer_client)).unwrap();
     }
 
     async fn task_dummy_timer_multi_sender(spawner: impl Spawn) {
@@ -437,6 +435,6 @@ mod tests {
     #[test]
     fn test_dummy_timer_multi_sender() {
         let thread_pool = ThreadPool::new().unwrap();
-        task::block_on(task_dummy_timer_multi_sender(thread_pool.clone()));
+        block_on(task_dummy_timer_multi_sender(thread_pool.clone()));
     }
 }


### PR DESCRIPTION
Restore `block_on()` code that relies on async-std after temporary workaround due to: https://github.com/async-rs/async-std/issues/811
Now using futures' `block_on()` instead of async-std's `task::block_on()`